### PR TITLE
Feature/add api driver

### DIFF
--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -285,7 +285,7 @@ class BotMan
             call_user_func($this->fallbackMessage, $this);
         }
 
-        $this->driver->afterAllMessages();
+        $this->driver->afterMessagesHandled();
     }
 
     /**

--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -284,6 +284,8 @@ class BotMan
             $this->message = $this->getMessages()[0];
             call_user_func($this->fallbackMessage, $this);
         }
+
+        $this->driver->afterAllMessages();
     }
 
     /**

--- a/src/Mpociot/BotMan/DriverManager.php
+++ b/src/Mpociot/BotMan/DriverManager.php
@@ -2,6 +2,7 @@
 
 namespace Mpociot\BotMan;
 
+use Mpociot\BotMan\Drivers\ApiDriver;
 use Mpociot\BotMan\Http\Curl;
 use Mpociot\BotMan\Drivers\Driver;
 use Mpociot\BotMan\Drivers\NullDriver;
@@ -31,6 +32,7 @@ class DriverManager
         NexmoDriver::class,
         HipChatDriver::class,
         WeChatDriver::class,
+        ApiDriver::class
     ];
 
     /** @var array */

--- a/src/Mpociot/BotMan/DriverManager.php
+++ b/src/Mpociot/BotMan/DriverManager.php
@@ -2,9 +2,9 @@
 
 namespace Mpociot\BotMan;
 
-use Mpociot\BotMan\Drivers\ApiDriver;
 use Mpociot\BotMan\Http\Curl;
 use Mpociot\BotMan\Drivers\Driver;
+use Mpociot\BotMan\Drivers\ApiDriver;
 use Mpociot\BotMan\Drivers\NullDriver;
 use Mpociot\BotMan\Drivers\NexmoDriver;
 use Mpociot\BotMan\Drivers\SlackDriver;

--- a/src/Mpociot/BotMan/DriverManager.php
+++ b/src/Mpociot/BotMan/DriverManager.php
@@ -32,7 +32,7 @@ class DriverManager
         NexmoDriver::class,
         HipChatDriver::class,
         WeChatDriver::class,
-        ApiDriver::class
+        ApiDriver::class,
     ];
 
     /** @var array */

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -4,8 +4,8 @@ namespace Mpociot\BotMan\Drivers;
 
 use Mpociot\BotMan\User;
 use Mpociot\BotMan\Answer;
-use Mpociot\BotMan\Message;
 use Illuminate\Support\Arr;
+use Mpociot\BotMan\Message;
 use Mpociot\BotMan\Question;
 use Illuminate\Support\Collection;
 use Mpociot\BotMan\Facebook\ListTemplate;
@@ -128,7 +128,7 @@ class ApiDriver extends Driver
             'messages' => $messages,
         ];
 
-        If ($this->errorMessage) {
+        if ($this->errorMessage) {
             $replyData['error'] = $this->errorMessage;
         }
 
@@ -159,7 +159,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Build API reply
+     * Build API reply.
      *
      * @param $messages
      * @return array
@@ -167,7 +167,6 @@ class ApiDriver extends Driver
     private function buildReply($messages)
     {
         $replyData = collect($messages)->transform(function ($message) {
-
             if ($message instanceof Question) {
                 $reply = $this->buildQuestionPayload($message);
             } elseif (is_object($message) && in_array(get_class($message), $this->templates)) {
@@ -186,7 +185,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Build reply payload for a Question object
+     * Build reply payload for a Question object.
      *
      * @param Question $message
      * @return array
@@ -208,7 +207,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Build reply payload for template objects
+     * Build reply payload for template objects.
      *
      * @param $message
      * @return array|bool|mixed
@@ -238,7 +237,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Generate payload for Facebook button template
+     * Generate payload for Facebook button template.
      *
      * @param ButtonTemplate $message
      * @return mixed
@@ -253,7 +252,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Generate payload for Facebook list template
+     * Generate payload for Facebook list template.
      *
      * @param $message
      * @return array
@@ -350,10 +349,10 @@ class ApiDriver extends Driver
         return collect($buttons)->map(function ($button) {
 
             switch ($button['type']) {
-                case 'button';
+                case 'button':
                     $button['type'] = 'postback';
                     break;
-                case 'url';
+                case 'url':
                     $button['type'] = 'web_url';
                     break;
             }

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -167,7 +167,7 @@ class ApiDriver extends Driver
             } else {
                 $reply = [
                     'type' => 'text',
-                    'text' => str_replace('##end##', '', $message),
+                    'text' => $message,
                 ];
             }
 
@@ -188,7 +188,7 @@ class ApiDriver extends Driver
         $questionsData = $message->toArray();
         $reply = [
             'type' => 'text',
-            'text' => str_replace('##end##', '', $questionsData['text']),
+            'text' => $questionsData['text'],
         ];
 
         if (! empty($message->getButtons())) {
@@ -212,7 +212,7 @@ class ApiDriver extends Driver
 
         if ($message instanceof ButtonTemplate) {
             $reply['type'] = 'buttonlist';
-            $reply['text'] = str_replace('##end##', '', Arr::get($message->toArray(), 'attachment.payload.text'));
+            $reply['text'] = Arr::get($message->toArray(), 'attachment.payload.text');
             $reply['buttons'] = Collection::make(Arr::get($message->toArray(),
                 'attachment.payload.buttons'))->map(function ($button) {
                 $returnArray = [
@@ -230,7 +230,7 @@ class ApiDriver extends Driver
         } else {
             $reply = [
                 'status' => 500,
-                'message' => 'unknown tempalte',
+                'message' => 'unknown template',
             ];
         }
 

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -240,7 +240,7 @@ class ApiDriver extends Driver
     /**
      * Send pending replies.
      */
-    public function afterAllMessages()
+    public function afterMessagesHandled()
     {
         if (count($this->replies)) {
             $this->sendResponse();

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -240,7 +240,7 @@ class ApiDriver extends Driver
     /**
      * Send pending replies.
      */
-    public function __destruct()
+    public function afterAllMessages()
     {
         if (count($this->replies)) {
             $this->sendResponse();

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -2,8 +2,6 @@
 
 namespace Mpociot\BotMan\Drivers;
 
-use Illuminate\Support\Facades\Log;
-use Mpociot\BotMan\Facebook\Element;
 use Mpociot\BotMan\User;
 use Mpociot\BotMan\Answer;
 use Mpociot\BotMan\Message;

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Mpociot\BotMan\Drivers;
+
+use Mpociot\BotMan\User;
+use Mpociot\BotMan\Answer;
+use Mpociot\BotMan\Message;
+use Illuminate\Support\Arr;
+use Mpociot\BotMan\Question;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Mpociot\BotMan\Facebook\ListTemplate;
+use Mpociot\BotMan\Facebook\ButtonTemplate;
+use Mpociot\BotMan\Facebook\GenericTemplate;
+use Mpociot\BotMan\Facebook\ReceiptTemplate;
+use Mpociot\BotMan\Interfaces\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Mpociot\BotMan\Messages\Message as IncomingMessage;
+
+class ApiDriver extends Driver
+{
+
+    /** @var Collection|ParameterBag */
+    protected $payload;
+
+    /** @var Collection */
+    protected $event;
+
+    /** @var array */
+    protected $templates = [
+        ButtonTemplate::class,
+        GenericTemplate::class,
+        ListTemplate::class,
+        ReceiptTemplate::class,
+    ];
+
+    const DRIVER_NAME = 'Api';
+
+    /**
+     * @param Request $request
+     */
+    public function buildPayload(Request $request)
+    {
+        $this->payload = $request->request->all();
+        $this->event = Collection::make($this->payload);
+    }
+
+    /**
+     * Return the driver name.
+     * @return string
+     */
+    public function getName()
+    {
+        return self::DRIVER_NAME;
+    }
+
+    /**
+     * Determine if the request is for this driver.
+     * @return bool
+     */
+    public function matchesRequest()
+    {
+        return $this->event->get('driver') === 'api';
+    }
+
+    /**
+     * @param  Message $message
+     * @return Answer
+     */
+    public function getConversationAnswer(Message $message)
+    {
+        return Answer::create($message->getMessage());
+    }
+
+    /**
+     * Retrieve the chat message.
+     * @return array
+     */
+    public function getMessages()
+    {
+        $message = $this->event->get('message');
+        $userId = $this->event->get('userId');
+
+        return [new Message($message, $userId, $userId, $this->payload)];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBot()
+    {
+        return false;
+    }
+
+    /**
+     * @param string|Question|IncomingMessage $message
+     * @param Message $matchingMessage
+     * @param array $additionalParameters
+     * @return $this|void
+     */
+    public function reply($message, $matchingMessage, $additionalParameters = [])
+    {
+        $cachedReplies = $this->getCachedMessages($message);
+
+        if ($this->isLastReply($message)) {
+            Cache::forget($this->event->get('userId'));
+            $messages = $this->buildReply($cachedReplies);
+
+            $replyData = [
+                'status' => 200,
+                'messages' => $messages
+            ];
+
+            Response::create(json_encode($replyData), 200, [
+                'Content-Type' => 'application/json',
+                'Access-Control-Allow-Credentials' => true,
+                'Access-Control-Allow-Origin' => '*'
+            ])->send();
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isConfigured()
+    {
+        return true;
+    }
+
+    /**
+     * Retrieve User information.
+     * @param Message $matchingMessage
+     * @return UserInterface
+     */
+    public function getUser(Message $matchingMessage)
+    {
+        return new User($matchingMessage->getChannel());
+    }
+
+    /**
+     * Build API reply
+     * @param $messages
+     * @return array
+     */
+    private function buildReply($messages)
+    {
+        $replyData = collect($messages)->transform(function ($message) {
+
+            if ($message instanceof Question) {
+                $reply = $this->buildQuestionPayload($message);
+            } elseif (is_object($message) && in_array(get_class($message), $this->templates)) {
+                $reply = $this->buildTemplatePayload($message);
+            } else {
+                $reply = [
+                    'type' => 'text',
+                    'text' => str_replace('##end##', '', $message)
+                ];
+            }
+
+            return $reply;
+
+        })->toArray();
+
+        return $replyData;
+    }
+
+    /**
+     * Check if this is the last reply of multiple ones
+     * @param $message
+     * @return bool|mixed
+     */
+    public function isLastReply($message)
+    {
+        if ($message instanceof Question) {
+            $message = $message->toArray()['text'];
+        } elseif (is_object($message) && in_array(get_class($message), $this->templates)) {
+            $message = Arr::get($message->toArray(), 'attachment.payload.text');
+        }
+
+        return strpos($message, '##end##') !== false;
+
+    }
+
+    /**
+     * Pull cached replies
+     * @param $message
+     * @return array
+     */
+    private function getCachedMessages($message)
+    {
+        $userId = $this->event->get('userId');
+        $cachedReplies = Cache::pull($userId);
+        $cachedReplies[] = $message;
+        Cache::put($userId, $cachedReplies, 100);
+
+        return $cachedReplies;
+    }
+
+    /**
+     * Build reply payload for a Question object
+     * @param Question $message
+     * @return array
+     */
+    private function buildQuestionPayload(Question $message)
+    {
+        $questionsData = $message->toArray();
+        $reply = [
+            'type' => 'text',
+            'text' => str_replace('##end##', '', $questionsData['text'])
+        ];
+
+        if ( ! empty($message->getButtons())) {
+            $reply['type'] = 'buttons';
+
+            $reply['buttons'] = Collection::make($message->getButtons())->map(function ($button) {
+                return [
+                    'text' => $button['text'],
+                    'keyword' => $button['value'],
+                    'imageUrl' => $button['image_url']
+                ];
+            })->toArray();
+        }
+
+        return $reply;
+    }
+
+    private function buildTemplatePayload($message)
+    {
+        $reply = [];
+
+        if ($message instanceof ButtonTemplate) {
+            $reply['type'] = 'buttonlist';
+            $reply['text'] = str_replace('##end##', '', Arr::get($message->toArray(), 'attachment.payload.text'));
+            $reply['buttons'] = Collection::make(Arr::get($message->toArray(),
+                'attachment.payload.buttons'))->map(function ($button) {
+                $returnArray = [
+                    'type' => $button['type'] === 'web_url' ? 'url' : 'postback',
+                    'text' => $button['title'],
+                    'keyword' => $button['payload'] ?? null
+                ];
+
+                if (isset($button['url'])) {
+                    $returnArray['url'] = $button['url'];
+                }
+
+                return $returnArray;
+            });
+        } else {
+            $reply = [
+                'status' => 500,
+                'message' => 'unknown tempalte'
+            ];
+        }
+
+        return $reply;
+    }
+}

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -21,7 +21,6 @@ use Mpociot\BotMan\Messages\Message as IncomingMessage;
 
 class ApiDriver extends Driver
 {
-
     /** @var Collection|ParameterBag */
     protected $payload;
 
@@ -49,6 +48,7 @@ class ApiDriver extends Driver
 
     /**
      * Return the driver name.
+     *
      * @return string
      */
     public function getName()
@@ -58,6 +58,7 @@ class ApiDriver extends Driver
 
     /**
      * Determine if the request is for this driver.
+     *
      * @return bool
      */
     public function matchesRequest()
@@ -76,6 +77,7 @@ class ApiDriver extends Driver
 
     /**
      * Retrieve the chat message.
+     *
      * @return array
      */
     public function getMessages()
@@ -110,13 +112,13 @@ class ApiDriver extends Driver
 
             $replyData = [
                 'status' => 200,
-                'messages' => $messages
+                'messages' => $messages,
             ];
 
             Response::create(json_encode($replyData), 200, [
                 'Content-Type' => 'application/json',
                 'Access-Control-Allow-Credentials' => true,
-                'Access-Control-Allow-Origin' => '*'
+                'Access-Control-Allow-Origin' => '*',
             ])->send();
         }
     }
@@ -131,6 +133,7 @@ class ApiDriver extends Driver
 
     /**
      * Retrieve User information.
+     *
      * @param Message $matchingMessage
      * @return UserInterface
      */
@@ -141,6 +144,7 @@ class ApiDriver extends Driver
 
     /**
      * Build API reply
+     *
      * @param $messages
      * @return array
      */
@@ -155,12 +159,11 @@ class ApiDriver extends Driver
             } else {
                 $reply = [
                     'type' => 'text',
-                    'text' => str_replace('##end##', '', $message)
+                    'text' => str_replace('##end##', '', $message),
                 ];
             }
 
             return $reply;
-
         })->toArray();
 
         return $replyData;
@@ -168,6 +171,7 @@ class ApiDriver extends Driver
 
     /**
      * Check if this is the last reply of multiple ones
+     *
      * @param $message
      * @return bool|mixed
      */
@@ -180,11 +184,11 @@ class ApiDriver extends Driver
         }
 
         return strpos($message, '##end##') !== false;
-
     }
 
     /**
      * Pull cached replies
+     *
      * @param $message
      * @return array
      */
@@ -200,6 +204,7 @@ class ApiDriver extends Driver
 
     /**
      * Build reply payload for a Question object
+     *
      * @param Question $message
      * @return array
      */
@@ -208,17 +213,17 @@ class ApiDriver extends Driver
         $questionsData = $message->toArray();
         $reply = [
             'type' => 'text',
-            'text' => str_replace('##end##', '', $questionsData['text'])
+            'text' => str_replace('##end##', '', $questionsData['text']),
         ];
 
-        if ( ! empty($message->getButtons())) {
+        if (! empty($message->getButtons())) {
             $reply['type'] = 'buttons';
 
             $reply['buttons'] = Collection::make($message->getButtons())->map(function ($button) {
                 return [
                     'text' => $button['text'],
                     'keyword' => $button['value'],
-                    'imageUrl' => $button['image_url']
+                    'imageUrl' => $button['image_url'],
                 ];
             })->toArray();
         }
@@ -238,7 +243,7 @@ class ApiDriver extends Driver
                 $returnArray = [
                     'type' => $button['type'] === 'web_url' ? 'url' : 'postback',
                     'text' => $button['title'],
-                    'keyword' => $button['payload'] ?? null
+                    'keyword' => $button['payload'] ?: null,
                 ];
 
                 if (isset($button['url'])) {
@@ -250,7 +255,7 @@ class ApiDriver extends Driver
         } else {
             $reply = [
                 'status' => 500,
-                'message' => 'unknown tempalte'
+                'message' => 'unknown tempalte',
             ];
         }
 

--- a/src/Mpociot/BotMan/Drivers/ApiDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ApiDriver.php
@@ -268,7 +268,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Generate payload for Facebook generic list template
+     * Generate payload for Facebook generic list template.
      *
      * @param $message
      * @return array
@@ -282,7 +282,7 @@ class ApiDriver extends Driver
     }
 
     /**
-     * Generate payload for Facebook receipt template
+     * Generate payload for Facebook receipt template.
      *
      * @param $message
      * @return array
@@ -347,7 +347,6 @@ class ApiDriver extends Driver
     private function generateButtonsPayload(array $buttons)
     {
         return collect($buttons)->map(function ($button) {
-
             switch ($button['type']) {
                 case 'button':
                     $button['type'] = 'postback';

--- a/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
+++ b/src/Mpociot/BotMan/Drivers/BotFrameworkDriver.php
@@ -209,7 +209,7 @@ class BotFrameworkDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/Driver.php
+++ b/src/Mpociot/BotMan/Drivers/Driver.php
@@ -24,6 +24,7 @@ abstract class Driver implements DriverInterface
 
     /**
      * Driver constructor.
+     *
      * @param Request $request
      * @param array $config
      * @param HttpInterface $http
@@ -61,9 +62,9 @@ abstract class Driver implements DriverInterface
     abstract public function buildPayload(Request $request);
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
-     abstract public function afterMessagesHandled();
+    abstract public function afterMessagesHandled();
 
     /**
      * Low-level method to perform driver specific API requests.

--- a/src/Mpociot/BotMan/Drivers/Driver.php
+++ b/src/Mpociot/BotMan/Drivers/Driver.php
@@ -43,4 +43,9 @@ abstract class Driver implements DriverInterface
      * @return void
      */
     abstract public function buildPayload(Request $request);
+
+    public function afterAllMessages()
+    {
+        // Define if something should be done after handling all messages
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/Driver.php
+++ b/src/Mpociot/BotMan/Drivers/Driver.php
@@ -44,8 +44,11 @@ abstract class Driver implements DriverInterface
      */
     abstract public function buildPayload(Request $request);
 
-    public function afterAllMessages()
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled()
     {
-        // Define if something should be done after handling all messages
+
     }
 }

--- a/src/Mpociot/BotMan/Drivers/FacebookDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FacebookDriver.php
@@ -254,7 +254,7 @@ class FacebookDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/FakeDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FakeDriver.php
@@ -21,7 +21,7 @@ use Mpociot\BotMan\Interfaces\DriverInterface;
  *      $this->fakeDriver = new FakeDriver();
  *      ProxyDriver::setInstance($this->fakeDriver);
  *  }
- * </code>
+ * </code>.
  */
 class FakeDriver implements DriverInterface
 {

--- a/src/Mpociot/BotMan/Drivers/FakeDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FakeDriver.php
@@ -135,4 +135,11 @@ class FakeDriver implements DriverInterface
         $this->botIsTyping = false;
         $this->botMessages = [];
     }
+
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled()
+    {
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/FakeDriver.php
+++ b/src/Mpociot/BotMan/Drivers/FakeDriver.php
@@ -10,9 +10,7 @@ use Mpociot\BotMan\Interfaces\DriverInterface;
 
 /**
  * A fake driver for tests. Must be used with ProxyDriver.
- *
  * Example to set it up in a unit test:
- *
  * <code>
  *  public static function setUpBeforeClass()
  *  {
@@ -29,15 +27,19 @@ class FakeDriver implements DriverInterface
 {
     /** @var bool */
     public $matchesRequest = true;
+
     /** @var Message[] */
     public $messages = [];
+
     /** @var bool */
     public $isBot = false;
+
     /** @var bool */
     public $isConfigured = true;
 
     /** @var array */
     private $botMessages = [];
+
     /** @var bool */
     private $botIsTyping = false;
 
@@ -137,7 +139,7 @@ class FakeDriver implements DriverInterface
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/HipChatDriver.php
+++ b/src/Mpociot/BotMan/Drivers/HipChatDriver.php
@@ -132,7 +132,7 @@ class HipChatDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/NexmoDriver.php
+++ b/src/Mpociot/BotMan/Drivers/NexmoDriver.php
@@ -126,7 +126,7 @@ class NexmoDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/NullDriver.php
+++ b/src/Mpociot/BotMan/Drivers/NullDriver.php
@@ -106,7 +106,7 @@ class NullDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/ProxyDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ProxyDriver.php
@@ -83,4 +83,11 @@ final class ProxyDriver implements DriverInterface
     {
         return self::instance()->types($matchingMessage);
     }
+
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled()
+    {
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/ProxyDriver.php
+++ b/src/Mpociot/BotMan/Drivers/ProxyDriver.php
@@ -85,7 +85,7 @@ final class ProxyDriver implements DriverInterface
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -277,7 +277,7 @@ class SlackDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -223,4 +223,11 @@ class SlackRTMDriver implements DriverInterface
     {
         return $this->client->apiCall($endpoint, $parameters, false, false);
     }
+
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled()
+    {
+    }
 }

--- a/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackRTMDriver.php
@@ -225,7 +225,7 @@ class SlackRTMDriver implements DriverInterface
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/TelegramDriver.php
+++ b/src/Mpociot/BotMan/Drivers/TelegramDriver.php
@@ -221,7 +221,7 @@ class TelegramDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Drivers/WeChatDriver.php
+++ b/src/Mpociot/BotMan/Drivers/WeChatDriver.php
@@ -152,7 +152,7 @@ class WeChatDriver extends Driver
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/src/Mpociot/BotMan/Facebook/ListTemplate.php
+++ b/src/Mpociot/BotMan/Facebook/ListTemplate.php
@@ -82,9 +82,7 @@ class ListTemplate implements JsonSerializable
                     'template_type' => 'list',
                     'top_element_style' => $this->top_element_style,
                     'elements' => $this->elements,
-                    'buttons' => [
-                        $this->globalButton,
-                    ],
+                    'buttons' => $this->globalButton ? [$this->globalButton] : []
                 ],
             ],
         ];

--- a/src/Mpociot/BotMan/Facebook/ListTemplate.php
+++ b/src/Mpociot/BotMan/Facebook/ListTemplate.php
@@ -82,7 +82,7 @@ class ListTemplate implements JsonSerializable
                     'template_type' => 'list',
                     'top_element_style' => $this->top_element_style,
                     'elements' => $this->elements,
-                    'buttons' => $this->globalButton ? [$this->globalButton] : []
+                    'buttons' => $this->globalButton ? [$this->globalButton] : [],
                 ],
             ],
         ];

--- a/src/Mpociot/BotMan/Interfaces/DriverInterface.php
+++ b/src/Mpociot/BotMan/Interfaces/DriverInterface.php
@@ -68,7 +68,7 @@ interface DriverInterface
     public function types(Message $matchingMessage);
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled();
 }

--- a/src/Mpociot/BotMan/Interfaces/DriverInterface.php
+++ b/src/Mpociot/BotMan/Interfaces/DriverInterface.php
@@ -66,4 +66,9 @@ interface DriverInterface
      * @return mixed
      */
     public function types(Message $matchingMessage);
+
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled();
 }

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -61,19 +61,19 @@ class DriverManagerTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_get_configured_drivers()
     {
-        $this->assertCount(0, DriverManager::getConfiguredDrivers([]));
+        $this->assertCount(1, DriverManager::getConfiguredDrivers([]));
 
-        $this->assertCount(1, DriverManager::getConfiguredDrivers([
+        $this->assertCount(2, DriverManager::getConfiguredDrivers([
             'slack_token' => 'foo',
         ]));
 
-        $this->assertCount(2, DriverManager::getConfiguredDrivers([
+        $this->assertCount(3, DriverManager::getConfiguredDrivers([
             'slack_token' => 'foo',
             'nexmo_key' => 'foo',
             'nexmo_secret' => 'foo',
         ]));
 
-        $this->assertCount(3, DriverManager::getConfiguredDrivers([
+        $this->assertCount(4, DriverManager::getConfiguredDrivers([
             'slack_token' => 'foo',
             'hipchat_urls' => ['foo'],
             'nexmo_key' => 'foo',

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Mpociot\BotMan\Tests\Drivers;
+
+use Mockery as m;
+use Mpociot\BotMan\Message;
+use Mpociot\BotMan\Http\Curl;
+use PHPUnit_Framework_TestCase;
+use Mpociot\BotMan\Drivers\ApiDriver;
+use Symfony\Component\HttpFoundation\Request;
+
+class ApiDriverTest extends PHPUnit_Framework_TestCase
+{
+    private function getDriver($responseData, $htmlInterface = null)
+    {
+        $request = Request::create('', 'POST', $responseData);
+        if ($htmlInterface === null) {
+            $htmlInterface = m::mock(Curl::class);
+        }
+
+        return new ApiDriver($request, [], $htmlInterface);
+    }
+
+    /** @test */
+    public function it_returns_the_driver_name()
+    {
+        $driver = $this->getDriver([]);
+        $this->assertSame('Api', $driver->getName());
+    }
+
+    /** @test */
+    public function it_matches_the_request()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+
+        $driver = $this->getDriver([
+            'driver' => 'api',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+        $this->assertTrue($driver->matchesRequest());
+    }
+
+    /** @test */
+    public function it_returns_the_message_object()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+        $this->assertTrue(is_array($driver->getMessages()));
+    }
+
+    /** @test */
+    public function it_returns_the_message_text()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+        $this->assertSame('Hi Julia', $driver->getMessages()[0]->getMessage());
+    }
+
+    /** @test */
+    public function it_returns_the_user_id()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+        $this->assertSame('12345', $driver->getMessages()[0]->getUser());
+    }
+
+    /** @test */
+    public function it_can_reply_string_messages()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345'
+        ]);
+
+        $message = new Message('', '', '1234567890');
+
+        $driver->reply('Test one From API', $message);
+        $driver->reply('Test two From API', $message);
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"text","text":"Test one From API"},{"type":"text","text":"Test two From API"}]}');
+    }
+}

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -13,8 +13,8 @@ use Mpociot\BotMan\Drivers\ApiDriver;
 use Mpociot\BotMan\Facebook\ListTemplate;
 use Mpociot\BotMan\Facebook\ElementButton;
 use Mpociot\BotMan\Facebook\ButtonTemplate;
-use Mpociot\BotMan\Facebook\ReceiptElement;
 use Mpociot\BotMan\Facebook\ReceiptAddress;
+use Mpociot\BotMan\Facebook\ReceiptElement;
 use Mpociot\BotMan\Facebook\ReceiptSummary;
 use Mpociot\BotMan\Facebook\GenericTemplate;
 use Mpociot\BotMan\Facebook\ReceiptTemplate;
@@ -220,8 +220,8 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * @test
-    **/
+     * @test
+     **/
     public function it_replies_to_facebook_receipt_template()
     {
         $driver = $this->getDriver([

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -3,8 +3,20 @@
 namespace Mpociot\BotMan\Tests\Drivers;
 
 use Mockery as m;
+use Mpociot\BotMan\Button;
+use Mpociot\BotMan\Facebook\ButtonTemplate;
+use Mpociot\BotMan\Facebook\Element;
+use Mpociot\BotMan\Facebook\ElementButton;
+use Mpociot\BotMan\Facebook\GenericTemplate;
+use Mpociot\BotMan\Facebook\ListTemplate;
+use Mpociot\BotMan\Facebook\ReceiptAddress;
+use Mpociot\BotMan\Facebook\ReceiptAdjustment;
+use Mpociot\BotMan\Facebook\ReceiptElement;
+use Mpociot\BotMan\Facebook\ReceiptSummary;
+use Mpociot\BotMan\Facebook\ReceiptTemplate;
 use Mpociot\BotMan\Message;
 use Mpociot\BotMan\Http\Curl;
+use Mpociot\BotMan\Question;
 use PHPUnit_Framework_TestCase;
 use Mpociot\BotMan\Drivers\ApiDriver;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,14 +46,14 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'driver' => 'web',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
         $this->assertFalse($driver->matchesRequest());
 
         $driver = $this->getDriver([
             'driver' => 'api',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
         $this->assertTrue($driver->matchesRequest());
     }
@@ -52,7 +64,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'driver' => 'web',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
         $this->assertTrue(is_array($driver->getMessages()));
     }
@@ -63,7 +75,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'driver' => 'web',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
         $this->assertSame('Hi Julia', $driver->getMessages()[0]->getMessage());
     }
@@ -74,7 +86,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'driver' => 'web',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
         $this->assertSame('12345', $driver->getMessages()[0]->getUser());
     }
@@ -85,7 +97,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'driver' => 'web',
             'message' => 'Hi Julia',
-            'userId' => '12345'
+            'userId' => '12345',
         ]);
 
         $message = new Message('', '', '1234567890');
@@ -95,5 +107,147 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
         $driver->afterMessagesHandled();
 
         $this->expectOutputString('{"status":200,"messages":[{"type":"text","text":"Test one From API"},{"type":"text","text":"Test two From API"}]}');
+    }
+
+    /**
+     * @test
+     **/
+    public function it_replies_to_question_object()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345',
+        ]);
+
+        $message = new Message('', '', '1234567890');
+        $question = Question::create('What do want to do?')
+            ->addButton(Button::create('Stay')->image('https://test.com/image.png')->value('stay'))
+            ->addButton(Button::create('Leave'));
+        $driver->reply($question, $message);
+        $driver->afterMessagesHandled();
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"buttons","text":"What do want to do?","buttons":[{"type":"postback","text":"Stay","value":"stay"},{"type":"postback","text":"Leave","value":null}]}]}');
+    }
+
+    /**
+     * @test
+     **/
+    public function it_replies_to_facebook_button_template()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345',
+        ]);
+
+        $message = new Message('', '', '1234567890');
+        $template = ButtonTemplate::create('How do you like BotMan so far?')
+            ->addButton(ElementButton::create('Quite good')->type('postback')->payload('good'))
+            ->addButton(ElementButton::create('Love it!')->url('https://test.at'));
+
+        $driver->reply($template, $message);
+        $driver->afterMessagesHandled();
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"buttons","text":"How do you like BotMan so far?","buttons":[{"type":"postback","text":"Quite good","value":"good"},{"type":"web_url","text":"Love it!","webUrl":"https:\/\/test.at"}]}]}');
+    }
+
+    /**
+     * @test
+     **/
+    public function it_replies_to_facebook_list_template()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345',
+        ]);
+
+        $message = new Message('', '', '1234567890');
+        $template = ListTemplate::create()
+            ->useCompactView()
+            ->addGlobalButton(
+                ElementButton::create('view more')
+                    ->url('http://test.at'))
+            ->addElement(
+                Element::create('BotMan Documentation')
+                    ->subtitle('All about BotMan')
+                    ->image('http://botman.io/img/botman-body.png')
+                    ->addButton(ElementButton::create('tell me more')->payload('tellmemore')->type('postback')))
+            ->addElement(
+                Element::create('BotMan Laravel Starter')
+                    ->image('http://botman.io/img/botman-body.png')
+                    ->addButton(ElementButton::create('visit')->url('https://github.com/mpociot/botman-laravel-starter'))
+            );
+
+        $driver->reply($template, $message);
+        $driver->afterMessagesHandled();
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"list","elements":[{"title":"BotMan Documentation","subtitle":"All about BotMan","imageUrl":"http:\/\/botman.io\/img\/botman-body.png","buttons":[{"type":"postback","text":"tell me more","value":"tellmemore"}]},{"title":"BotMan Laravel Starter","subtitle":null,"imageUrl":"http:\/\/botman.io\/img\/botman-body.png","buttons":[{"type":"web_url","text":"visit","webUrl":"https:\/\/github.com\/mpociot\/botman-laravel-starter"}]}],"globalButtons":[{"type":"web_url","text":"view more","webUrl":"http:\/\/test.at"}]}]}');
+    }
+
+    /**
+     * @test
+     **/
+    public function it_replies_to_facebook_generic_template()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345',
+        ]);
+
+        $message = new Message('', '', '1234567890');
+        $template = GenericTemplate::create()
+            ->addElements([
+                Element::create('BotMan Documentation')
+                    ->itemUrl('http://botman.io/')
+                    ->image('http://screenshots.nomoreencore.com/botman2.png')
+                    ->subtitle('All about BotMan')
+                    ->addButton(ElementButton::create('visit')->url('http://botman1.io'))
+                    ->addButton(ElementButton::create('tell me more')->payload('tellmemore')->type('postback')),
+                Element::create('BotMan Laravel Starter')
+                    ->itemUrl('https://github.com/mpociot/botman-laravel-starter')
+                    ->image('http://screenshots.nomoreencore.com/botman.png')
+                    ->subtitle('This is the best way to start with Laravel and BotMan')
+                    ->addButton(ElementButton::create('visit')->url('https://github.com/mpociot/botman-laravel-starter')),
+        ]);
+
+        $driver->reply($template, $message);
+        $driver->afterMessagesHandled();
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"list","elements":[{"title":"BotMan Documentation","subtitle":"All about BotMan","imageUrl":"http:\/\/screenshots.nomoreencore.com\/botman2.png","itemUrl":"http:\/\/botman.io\/","buttons":[{"type":"web_url","text":"visit","webUrl":"http:\/\/botman1.io"},{"type":"postback","text":"tell me more","value":"tellmemore"}]},{"title":"BotMan Laravel Starter","subtitle":"This is the best way to start with Laravel and BotMan","imageUrl":"http:\/\/screenshots.nomoreencore.com\/botman.png","itemUrl":"https:\/\/github.com\/mpociot\/botman-laravel-starter","buttons":[{"type":"web_url","text":"visit","webUrl":"https:\/\/github.com\/mpociot\/botman-laravel-starter"}]}]}]}');
+    }
+
+    /**
+    * @test
+    **/
+    public function it_replies_to_facebook_receipt_template()
+    {
+        $driver = $this->getDriver([
+            'driver' => 'web',
+            'message' => 'Hi Julia',
+            'userId' => '12345',
+        ]);
+
+        $message = new Message('', '', '1234567890');
+        $template = ReceiptTemplate::create()
+            ->recipientName('Christoph Rumpel')
+            ->merchantName('BotMan GmbH')
+            ->orderNumber('342343434343')
+            ->timestamp('1428444852')
+            ->orderUrl('http://test.at')
+            ->currency('USD')
+            ->paymentMethod('VISA')
+            ->addElement(ReceiptElement::create('T-Shirt Small')->price(15.99)->image('http://botman.io/img/botman-body.png')->quantity(2)->subtitle('v1')->currency('USD'))
+            ->addElement(ReceiptElement::create('Sticker')->price(2.99)->image('http://botman.io/img/botman-body.png')->subtitle('Logo 1')->currency('USD'))
+            ->addAddress(ReceiptAddress::create()->street1('Watsonstreet 12')->city('Bot City')->postalCode(100000)->state('Washington AI')->country('Botmanland'))
+            ->addSummary(ReceiptSummary::create()->subtotal(18.98)->shippingCost(10)->totalTax(15)->totalCost(23.98))
+            ->addAdjustment(ReceiptAdjustment::create('Laravel Bonus')->amount(5));
+
+        $driver->reply($template, $message);
+        $driver->afterMessagesHandled();
+
+        $this->expectOutputString('{"status":200,"messages":[{"type":"receipt","recipient_name":"Christoph Rumpel","merchant_name":"BotMan GmbH","order_number":"342343434343","currency":"USD","payment_method":"VISA","order_url":"http:\/\/test.at","timestamp":"1428444852","elements":[{"title":"T-Shirt Small","subtitle":"v1","imageUrl":"http:\/\/botman.io\/img\/botman-body.png","quantity":2,"price":15.99,"currency":"USD"},{"title":"Sticker","subtitle":"Logo 1","imageUrl":"http:\/\/botman.io\/img\/botman-body.png","quantity":null,"price":2.99,"currency":"USD"}],"address":{"street_1":"Watsonstreet 12","street_2":null,"city":"Bot City","postal_code":100000,"state":"Washington AI","country":"Botmanland"},"summary":{"subtotal":18.98,"shipping_cost":10,"total_tax":15,"total_cost":23.98},"adjustments":[{"name":"Laravel Bonus","amount":5}]}]}');
     }
 }

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -4,22 +4,22 @@ namespace Mpociot\BotMan\Tests\Drivers;
 
 use Mockery as m;
 use Mpociot\BotMan\Button;
-use Mpociot\BotMan\Facebook\ButtonTemplate;
-use Mpociot\BotMan\Facebook\Element;
-use Mpociot\BotMan\Facebook\ElementButton;
-use Mpociot\BotMan\Facebook\GenericTemplate;
-use Mpociot\BotMan\Facebook\ListTemplate;
-use Mpociot\BotMan\Facebook\ReceiptAddress;
-use Mpociot\BotMan\Facebook\ReceiptAdjustment;
-use Mpociot\BotMan\Facebook\ReceiptElement;
-use Mpociot\BotMan\Facebook\ReceiptSummary;
-use Mpociot\BotMan\Facebook\ReceiptTemplate;
 use Mpociot\BotMan\Message;
-use Mpociot\BotMan\Http\Curl;
 use Mpociot\BotMan\Question;
+use Mpociot\BotMan\Http\Curl;
 use PHPUnit_Framework_TestCase;
+use Mpociot\BotMan\Facebook\Element;
 use Mpociot\BotMan\Drivers\ApiDriver;
+use Mpociot\BotMan\Facebook\ListTemplate;
+use Mpociot\BotMan\Facebook\ElementButton;
+use Mpociot\BotMan\Facebook\ButtonTemplate;
+use Mpociot\BotMan\Facebook\ReceiptElement;
+use Mpociot\BotMan\Facebook\ReceiptAddress;
+use Mpociot\BotMan\Facebook\ReceiptSummary;
+use Mpociot\BotMan\Facebook\GenericTemplate;
+use Mpociot\BotMan\Facebook\ReceiptTemplate;
 use Symfony\Component\HttpFoundation\Request;
+use Mpociot\BotMan\Facebook\ReceiptAdjustment;
 
 class ApiDriverTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -92,6 +92,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
 
         $driver->reply('Test one From API', $message);
         $driver->reply('Test two From API', $message);
+        $driver->afterAllMessages();
 
         $this->expectOutputString('{"status":200,"messages":[{"type":"text","text":"Test one From API"},{"type":"text","text":"Test two From API"}]}');
     }

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -92,7 +92,7 @@ class ApiDriverTest extends PHPUnit_Framework_TestCase
 
         $driver->reply('Test one From API', $message);
         $driver->reply('Test two From API', $message);
-        $driver->afterAllMessages();
+        $driver->afterMessagesHandled();
 
         $this->expectOutputString('{"status":200,"messages":[{"type":"text","text":"Test one From API"},{"type":"text","text":"Test two From API"}]}');
     }

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -100,7 +100,7 @@ class TestDriver implements DriverInterface
     }
 
     /**
-     * Define if something should be done after handling all messages
+     * Define if something should be done after handling all messages.
      */
     public function afterMessagesHandled()
     {

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -98,4 +98,11 @@ class TestDriver implements DriverInterface
     {
         return new User();
     }
+
+    /**
+     * Define if something should be done after handling all messages
+     */
+    public function afterMessagesHandled()
+    {
+    }
 }


### PR DESCRIPTION
So this is the first draft of a working API driver. It should state why I think it could benefit the library and point out some of the current problems. I hope we can together figure out how it would fit to BotMan and how to solve the remaining problems.

**Usecase:**

We are building right now a chatbot for an insurance company and it will be on Facebook and on their website. We are using BotMan and it works great for FB. We also wanted to use it for the website, this is why I built this ApiDriver. We will see much more chatbots on websites too in the future and this is why I think an API would make total sense.

**How it works:**
It is receiving data, like the other drivers, over the webhook. For example this JSON:
```json
{
	"driver": "api",
	"message": "hello",
	"userId": "12345"
}
```

Through the driver property it will match the ApiDriver. And of course there is a `message` and a `userId` to save the user.

This could return (depending on your `hears` method, JSON as well:

```json
{
	"status": 200,
	"messages": [
		{
			"type": "text",
			"text": "hello you too"
		}
	]
}
```

**Decisions**
First decision I had to make was about the `return` of the driver. The other drivers are sending separate requests to their messenger back. I did not want to do that because of these reasons:

- websites are not like messenger platforms
- every website will be different, as well as the frontend
- every website would need an API to handle the returns form the ApiDriver

This why I decided `not` to send requests, and just response to the initial request with the data. This would give websites the possibility to handle their chatbot logic (frontend, backend) as they like and BotMan does not need to know about how the websites work. BotMan just provides an API everyone can use.

**Problems:**
With this decision there is one big problem. In BotMan you can send multiple replies like: 
```php
$this->say('Nice to meet you '.$this->firstname);
$this->askEmail();
```

With the FacebookDriver this would send two request to the FB api, but with the ApiDriver we just have one return and this is a problem, because both `say` and `askEmail` are treated separately without knowing if there are more grouped messages coming.

**Hack**
To solve that I am using right now a little hack.
```php
$botman->hears('hello', function(BotMan $botMan) {
           $botMan->reply('hey');
           $botMan->reply('hello you too##end##');
});
```
I am adding a `tag` like `##end##` to the last of the "grouped messages". The ApiDriver will store all messages in the cache, until a message has this end. Then it will grab all the messages and send them together as one response. (of course clearing the tag out before)
```JSON
{
	"status": 200,
	"messages": [
		{
			"type": "text",
			"text": "hey"
		},
		{
			"type": "text",
			"text": "hello you too"
		}
	]
}
````
This was the only way I could think of of to easily make this work. As mentioned this is working perfectly in production for me, but maybe it is not the best solution for BotMan. Here I could need help.

**Templates:**
Of course the API needs to handle different templates too, because your website needs to know if it should show buttons or an image etc.
So a question like this:
```php
$botman->hears('hello', function(BotMan $botMan) {
            $question = Question::create('What do want to do?##end##')
                ->addButton(Button::create('Stay'))
                ->addButton(Button::create('Leave'));
           $botMan->reply($question);
        });
```
would get a response like this:
```json
{
	"status": 200,
	"messages": [
		{
			"type": "buttons",
			"text": "What do want to do?",
			"buttons": [
				{
					"text": "Stay",
					"keyword": null,
					"imageUrl": null
				},
				{
					"text": "Leave",
					"keyword": null,
					"imageUrl": null
				}
			]
		}
	]
}
Then the website can decide how to use this information.
```

**Missing:**

Big parts I see missing right now are:

- Solution for the `tag problem`
- Not all templates are covered yet (there are lots of them 😄)
- tests are missing (wanted to talk about the other stuff first)

So it would be great to get some feedback and I hope we can  bring a cool new driver to BotMan :-)

PS: It is great for testing too :-)