### PR TITLE
FB:Messenger - add fallback attachments to Message

### DIFF
--- a/src/Drivers/Facebook/FacebookDriver.php
+++ b/src/Drivers/Facebook/FacebookDriver.php
@@ -190,7 +190,12 @@ class FacebookDriver extends HttpDriver
         $messages = Collection::make($this->event->get('messaging'));
         $messages = $messages->transform(function ($msg) {
             if (isset($msg['message']) && isset($msg['message']['text'])) {
-                return new Message($msg['message']['text'], $msg['sender']['id'], $msg['recipient']['id'], $msg);
+                $message = new Message($msg['message']['text'], $msg['sender']['id'], $msg['recipient']['id'], $msg);
+                if (isset($msg['message']['attachments'])) {
+                    $message->setAttachments(Collection::make($msg['message']['attachments'])->where('type', 'fallback')->toArray());
+                }
+
+                return $message;
             }
 
             return new Message('', '', '');


### PR DESCRIPTION
If an article from an app (ie amazon) is shared to messenger not all information is accessible in the Message object.

```
diver=Facebook
message=Share Message
payload={
  "sender": {
    "id": "***"
  },
  "recipient": {
    "id": "***"
  },
  "timestamp": 1496405313226,
  "message": {
    "mid": "***",
    "seq": 93174,
    "text": "Dyon Enter 32 Pro 80 cm",
    "attachments": [
      {
        "title": "Dyon Enter 32 Pro 80 cm (31,5 Zoll) Fernseher (Triple Tuner, DVB-T2 H.265\/HEVC)",
        "url": "https:\/\/l.facebook.com\/l.php?u=https%3A%2F%2Fwww.amazon.de%2Fdp%2FB01BDR9Q6W%2Fref%3Dtsm_1_fb_lk&h=ATPqFsVfY3VG0rxliUSbuTVgSorY-IgOYHW2jbD1hQo6zbiLspRKfzol03eZAOgf0iX3SdoNNuvyBUjXkRZeZZ_fQvzBH1hyKPo_4QBsTQE2KuT1jA&s=1&enc=AZOIVQu_YgLSllcGJ62IrqkSJ4_TEWeNuOQZJf_6Zs2Mdw_Y6SqOvc3klOaLTzzmdYKQriS9lI_HU-X9yzOPtSDS",
        "type": "fallback",
        "payload": null
      }
    ]
  }
}
``` 


this change adds all the fallback objects to getAttachments()