### PR TITLE
Added Authentication to RedisStorage

### DIFF
--- a/src/Mpociot/BotMan/Storages/Drivers/RedisStorage.php
+++ b/src/Mpociot/BotMan/Storages/Drivers/RedisStorage.php
@@ -17,19 +17,22 @@ class RedisStorage implements StorageInterface
     private $redis;
     private $host;
     private $port;
+    private $auth;
 
     /**
      * RedisCache constructor.
      * @param $host
      * @param $port
+     * @param $auth
      */
-    public function __construct($host = '127.0.0.1', $port = 6379)
+    public function __construct($host = '127.0.0.1', $port = 6379, $auth = null)
     {
         if (! class_exists(Redis::class)) {
             throw new RuntimeException('phpredis extension is required for RedisStorage');
         }
         $this->host = $host;
         $this->port = $port;
+        $this->auth = $auth;
         $this->connect();
     }
 
@@ -99,6 +102,10 @@ class RedisStorage implements StorageInterface
     {
         $this->redis = new Redis();
         $this->redis->connect($this->host, $this->port);
+        if ($this->auth !== null) {
+            $this->redis->auth($this->auth);
+        }
+
         if (function_exists('igbinary_serialize') && defined('Redis::SERIALIZER_IGBINARY')) {
             $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
         } else {

--- a/tests/Storages/RedisStorageTest.php
+++ b/tests/Storages/RedisStorageTest.php
@@ -3,6 +3,7 @@
 namespace Mpociot\BotMan\Tests;
 
 use Redis;
+use RedisException;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Support\Collection;
 use Mpociot\BotMan\Storages\Drivers\RedisStorage;
@@ -21,10 +22,38 @@ class RedisStorageTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        $script = sprintf("for i, name in ipairs(redis.call('KEYS', '%s*')) do redis.call('DEL', name); end", RedisStorage::KEY_PREFIX);
+
         $redis = new Redis();
         $redis->connect('127.0.0.1');
-        $script = sprintf("for i, name in ipairs(redis.call('KEYS', '%s*')) do redis.call('DEL', name); end", RedisStorage::KEY_PREFIX);
         $redis->eval($script);
+        $redis->close();
+
+        $redis = new Redis();
+        $redis->connect('127.0.0.1', 6380);
+        $redis->auth('secret');
+        $redis->eval($script);
+        $redis->close();
+    }
+
+    /** @test */
+    public function valid_auth()
+    {
+        $storage = new RedisStorage('127.0.0.1', 6380, 'secret');
+        $key = 'key';
+        $data = ['foo' => 1, 'bar' => new \DateTime()];
+        $storage->save($data, $key);
+        self::assertEquals(Collection::make($data), $storage->get($key));
+    }
+
+    /** @test */
+    public function invalid_auth()
+    {
+        static::setExpectedException(RedisException::class);
+        $storage = new RedisStorage('127.0.0.1', 6380, 'invalid');
+        $key = 'key';
+        $data = ['foo' => 1, 'bar' => new \DateTime()];
+        $storage->save($data, $key);
     }
 
     /** @test */


### PR DESCRIPTION
This is similar to what has been discussed on #432 but targeted to the Storage system.

Note: This PR requires changes to `travis.yml` made by #438 to be merged first (not sure how to handle it in a more clean way).