### PR TITLE
Fix for regex parameters count

### DIFF
--- a/src/Mpociot/BotMan/BotMan.php
+++ b/src/Mpociot/BotMan/BotMan.php
@@ -357,7 +357,7 @@ class BotMan
                     $this->message = $message;
                     $heardMessage = true;
                     $parameterNames = $this->compileParameterNames($pattern);
-                    $matches = array_slice($matches, 1);
+                    $matches = array_slice($matches, count($matches) - 1);
                     if (count($parameterNames) === count($matches)) {
                         $parameters = array_combine($parameterNames, $matches);
                     } else {


### PR DESCRIPTION
When Regex and dynamic parameter is used on hears, $matches is wrong, this fix will put the right count for the $matches array.