### PR TITLE
Allow adding of plain array buttons on Element class

### DIFF
--- a/src/Mpociot/BotMan/Facebook/Element.php
+++ b/src/Mpociot/BotMan/Facebook/Element.php
@@ -83,12 +83,12 @@ class Element implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
+     * @param array|ElementButton $button
      * @return $this
      */
-    public function addButton(ElementButton $button)
+    public function addButton($button)
     {
-        $this->buttons[] = $button->toArray();
+        $this->buttons[] = $button instanceof ElementButton ? $button->toArray() : $button;
 
         return $this;
     }
@@ -101,9 +101,7 @@ class Element implements JsonSerializable
     {
         if (isset($buttons) && is_array($buttons)) {
             foreach ($buttons as $button) {
-                if ($button instanceof ElementButton) {
-                    $this->buttons[] = $button->toArray();
-                }
+                $this->buttons[] = $button instanceof ElementButton ? $button->toArray() : $button;
             }
         }
 

--- a/tests/Facebook/ElementTest.php
+++ b/tests/Facebook/ElementTest.php
@@ -116,5 +116,7 @@ class ElementTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertSame('element_share', Arr::get($template->toArray(), 'buttons.0.type'));
+        $this->assertSame('postback', Arr::get($template->toArray(), 'buttons.1.type'));
+        $this->assertSame('button3', Arr::get($template->toArray(), 'buttons.2.title'));
     }
 }

--- a/tests/Facebook/ElementTest.php
+++ b/tests/Facebook/ElementTest.php
@@ -90,7 +90,7 @@ class ElementTest extends PHPUnit_Framework_TestCase
         $template = new Element('Here are some buttons');
 
         $template->addButton([
-            'type' => 'element_share'
+            'type' => 'element_share',
         ]);
 
         $this->assertSame('element_share', Arr::get($template->toArray(), 'buttons.0.type'));
@@ -105,14 +105,14 @@ class ElementTest extends PHPUnit_Framework_TestCase
 
         $template->addButtons([
             [
-                'type' => 'element_share'
+                'type' => 'element_share',
             ],
             [
-                'type'    => 'postback',
-                'title'   => 'Element 2',
-                'payload' => 'ELEMENT_2'
+                'type' => 'postback',
+                'title' => 'Element 2',
+                'payload' => 'ELEMENT_2',
             ],
-            ElementButton::create('button3')
+            ElementButton::create('button3'),
         ]);
 
         $this->assertSame('element_share', Arr::get($template->toArray(), 'buttons.0.type'));

--- a/tests/Facebook/ElementTest.php
+++ b/tests/Facebook/ElementTest.php
@@ -81,4 +81,40 @@ class ElementTest extends PHPUnit_Framework_TestCase
         $this->assertSame('button1', Arr::get($template->toArray(), 'buttons.0.title'));
         $this->assertSame('button2', Arr::get($template->toArray(), 'buttons.1.title'));
     }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_plain_array_button()
+    {
+        $template = new Element('Here are some buttons');
+
+        $template->addButton([
+            'type' => 'element_share'
+        ]);
+
+        $this->assertSame('element_share', Arr::get($template->toArray(), 'buttons.0.type'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_multiple_plain_array_buttons()
+    {
+        $template = new Element('Here are some buttons');
+
+        $template->addButtons([
+            [
+                'type' => 'element_share'
+            ],
+            [
+                'type'    => 'postback',
+                'title'   => 'Element 2',
+                'payload' => 'ELEMENT_2'
+            ],
+            ElementButton::create('button3')
+        ]);
+
+        $this->assertSame('element_share', Arr::get($template->toArray(), 'buttons.0.type'));
+    }
 }


### PR DESCRIPTION
Allow adding of plain array buttons on Element class for adding button type of "element_share" for Messenger Platform