### PR TITLE
Bugifix in combination of Regex and Parameters on hears commands and improved matches result

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -361,11 +361,22 @@ class BotMan
             $this->message = $this->middleware->applyMiddleware('heard', $matchingMessage->getMessage(), $this->command->getMiddleware());
             $parameterNames = $this->compileParameterNames($this->command->getPattern());
 
-            $matches = $matchingMessage->getMatches();
-            if (count($parameterNames) === count($matches)) {
-                $parameters = array_combine($parameterNames, $matches);
-            } else {
-                $parameters = $matches;
+            $parameters = $matchingMessage->getMatches();
+            if (count($parameterNames) !== count($parameters)) {
+                $parameters = array_merge(
+                    //First, all named parameters (eg. function ($a, $b, $c))
+                    array_filter(
+                        $parameters,
+                        'is_string',
+                        ARRAY_FILTER_USE_KEY
+                    ),
+                    //Then, all other unsorted parameters (regex non named results)
+                    array_filter(
+                        $parameters,
+                        'is_integer',
+                        ARRAY_FILTER_USE_KEY
+                    )
+                );
             }
 
             $this->matches = $parameters;

--- a/src/Messages/Matcher.php
+++ b/src/Messages/Matcher.php
@@ -52,7 +52,7 @@ class Matcher
         }
 
         $pattern = str_replace('/', '\/', $pattern);
-        $text = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(.*)', $pattern).'$/miu';
+        $text = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'$/miu';
 
         $regexMatched = (bool) preg_match($text, $message->getText(), $this->matches) || (bool) preg_match($text, $answerText, $this->matches);
 

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -567,7 +567,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
                 'sender' => 'UX12345',
                 'recipient' => 'general',
                 'message' => 'You are Gandalf a grey',
-            ])
+            ]),
         ];
 
         foreach ($botmans as $botman) {
@@ -598,7 +598,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
                 'sender' => 'UX12345',
                 'recipient' => 'general',
                 'message' => 'You are Gandalf',
-            ])
+            ]),
         ];
 
         foreach ($botmans as $botman) {

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -553,6 +553,67 @@ class BotManTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_returns_regular_expression_combined_matches()
+    {
+        $called = false;
+
+        $botmans = [
+            $this->getBot([
+                'sender' => 'UX12345',
+                'recipient' => 'general',
+                'message' => 'I am Gandalf the grey',
+            ]),
+            $this->getBot([
+                'sender' => 'UX12345',
+                'recipient' => 'general',
+                'message' => 'You are Gandalf a grey',
+            ])
+        ];
+
+        foreach ($botmans as $botman) {
+            $botman->hears('(I am|You are) {name} (the|a) {attribute}', function ($bot, $name, $attribute) use (&$called) {
+                $called = true;
+
+                $this->assertSame('Gandalf', $name);
+                $this->assertSame('grey', $attribute);
+            });
+        }
+
+        $botman->listen();
+        $this->assertTrue($called);
+    }
+
+    /** @test */
+    public function it_returns_the_combined_matches()
+    {
+        $called = false;
+
+        $botmans = [
+            $this->getBot([
+                'sender' => 'UX12345',
+                'recipient' => 'general',
+                'message' => 'I am Gandalf',
+            ]),
+            $this->getBot([
+                'sender' => 'UX12345',
+                'recipient' => 'general',
+                'message' => 'You are Gandalf',
+            ])
+        ];
+
+        foreach ($botmans as $botman) {
+            $botman->hears('(I am|You are) {name}', function ($bot, $name) use (&$called) {
+                $called = true;
+
+                $this->assertSame('Gandalf', $name);
+            });
+        }
+
+        $botman->listen();
+        $this->assertTrue($called);
+    }
+
+    /** @test */
     public function it_can_store_conversations()
     {
         $botman = $this->getBot([


### PR DESCRIPTION
There was a bug in the regex pattern commands and BotMan matches handling, example command:
```
$botman->hears('(I am|You are) {name}', function ($bot, $name) {
    //$name should be the content of {name} but was "I am" or "You are"
});
```

Tests are provided and passed.