### PR TITLE
Allow rich reply on slack slash commands

### DIFF
--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -9,6 +9,7 @@ use Mpociot\BotMan\Question;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Mpociot\BotMan\Messages\Message as IncomingMessage;
 
@@ -124,7 +125,7 @@ class SlackDriver extends Driver
         if (! Collection::make($matchingMessage->getPayload())->has('team_domain')) {
             $this->replyWithToken($message, $matchingMessage, $additionalParameters);
         } elseif ($this->isSlashCommand()) {
-            $this->respondText($message, $matchingMessage, $additionalParameters);
+            $this->respondJSON($message, $matchingMessage, $additionalParameters);
         } else {
             $this->respondJSON($message, $matchingMessage, $additionalParameters);
         }
@@ -167,7 +168,7 @@ class SlackDriver extends Driver
             $parameters['text'] = $this->format($message);
         }
 
-        Response::create(json_encode($parameters))->send();
+        JsonResponse::create($parameters)->send();
     }
 
     /**


### PR DESCRIPTION
This allows to respond with rich formatted messages on Slack slash commands https://api.slack.com/slash-commands#responding_to_a_command you can do things like:

```php
$bot->reply('Hello!', [
    'response_type' => 'in_channel',
]);
```

Which make's possible to reply with a message for everyone on the channel you run the command. Kind of what giphy does when you request a gif and instantly respond on "public" mode to the whole channel.