### PR TITLE
Do not user Laravel class_basename function in ExceptionHandler

### DIFF
--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -25,7 +25,7 @@ class ExceptionHandler implements ExceptionHandlerInterface
      */
     public function handleException($e, BotMan $bot)
     {
-        $exceptions = $this->exceptions->where('exception', class_basename($e));
+        $exceptions = $this->exceptions->where('exception', (new \ReflectionClass($e))->getShortName());
 
         $exceptions->each(function ($handler) use ($e, $bot) {
             call_user_func_array($handler['closure'], [$e, $bot]);


### PR DESCRIPTION
In the new ExceptionHandler added, the function `class_basename` is used, it is a Laravel function, we shouldn't use it as Botman wants to be framework agnostic.