### PR TITLE
RFC User raw data method

### DIFF
--- a/src/Interfaces/UserInterface.php
+++ b/src/Interfaces/UserInterface.php
@@ -23,4 +23,10 @@ interface UserInterface
      * @return string
      */
     public function getLastName();
+
+    /**
+     * Get raw driver's user info.
+     * @return array
+     */
+    public function getInfo();
 }

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -35,7 +35,7 @@ class User implements UserInterface
         $this->first_name = $first_name;
         $this->last_name = $last_name;
         $this->username = $username;
-        $this->user_info = (array)$user_info;
+        $this->user_info = (array) $user_info;
     }
 
     /**
@@ -71,8 +71,8 @@ class User implements UserInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getInfo()
     {
         return $this->user_info;

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -35,7 +35,7 @@ class User implements UserInterface
         $this->first_name = $first_name;
         $this->last_name = $last_name;
         $this->username = $username;
-        $this->user_info = $user_info;
+        $this->user_info = (array)$user_info;
     }
 
     /**

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -18,19 +18,24 @@ class User implements UserInterface
     /** @var string */
     protected $username;
 
+    /** @var array */
+    protected $user_info;
+
     /**
      * User constructor.
      * @param $id
      * @param $first_name
      * @param $last_name
      * @param $username
+     * @param $user_info
      */
-    public function __construct($id = null, $first_name = null, $last_name = null, $username = null)
+    public function __construct($id = null, $first_name = null, $last_name = null, $username = null, $user_info = [])
     {
         $this->id = $id;
         $this->first_name = $first_name;
         $this->last_name = $last_name;
         $this->username = $username;
+        $this->user_info = $user_info;
     }
 
     /**
@@ -63,5 +68,13 @@ class User implements UserInterface
     public function getLastName()
     {
         return $this->last_name;
+    }
+
+    /**
+    * {@inheritdoc}
+    */
+    public function getInfo()
+    {
+        return $this->user_info;
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace BotMan\BotMan\tests;
+
+use BotMan\BotMan\Users\User;
+use PHPUnit_Framework_TestCase;
+
+class UserTest extends PHPUnit_Framework_TestCase
+{
+    private $userId = 'U023BECGF';
+    private $userFirstName = 'Bobby';
+    private $userLastName = 'Tables';
+    private $userUsername = 'bobby';
+    private $userUserInfos = [
+        'id' => 'U023BECGF',
+        'name' => 'bobby',
+        'deleted' => false,
+        'color' => '9f69e7',
+        'profile' =>  [
+            'avatar_hash' => 'ge3b51ca72de',
+            'current_status' => ':mountain_railway => riding a train',
+            'first_name' => 'Bobby',
+            'last_name' => 'Tables',
+            'real_name' => 'Bobby Tables',
+            'tz' => 'America\/Los_Angeles',
+            'tz_label' => 'Pacific Daylight Time',
+            'tz_offset' => -25200,
+            'email' => 'bobby@slack.com',
+            'skype' => 'my-skype-name',
+            'phone' => '+1 (123) 456 7890',
+            'image_24' => 'https:\/\/...',
+            'image_32' => 'https:\/\/...',
+            'image_48' => 'https:\/\/...',
+            'image_72' => 'https:\/\/...',
+            'image_192' => 'https:\/\/...'
+        ],
+        'is_admin' => true,
+        'is_owner' => true,
+        'updated' => 1490054400,
+        'has_2fa' => true
+    ];
+
+    private function getTestUser()
+    {
+        $user = new User($this->userId, $this->userFirstName, $this->userLastName, $this->userUsername, $this->userUserInfos);
+        return $user;
+    }
+
+    /** @test */
+    public function it_can_get_user_id()
+    {
+        $user = $this->getTestUser();
+        $this->assertSame($this->userId, $user->getId());
+    }
+
+    /** @test */
+    public function it_can_get_user_firstname()
+    {
+        $user = $this->getTestUser();
+        $this->assertSame($this->userFirstName, $user->getFirstName());
+    }
+
+    /** @test */
+    public function it_can_get_user_lastname()
+    {
+        $user = $this->getTestUser();
+        $this->assertSame($this->userLastName, $user->getLastName());
+    }
+
+    /** @test */
+    public function it_can_get_user_username()
+    {
+        $user = $this->getTestUser();
+        $this->assertSame($this->userUsername, $user->getUsername());
+    }
+
+    /** @test */
+    public function it_can_get_user_userinfos()
+    {
+        $user = $this->getTestUser();
+        $this->assertSame($this->userUserInfos, $user->getInfo());
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -43,6 +43,7 @@ class UserTest extends PHPUnit_Framework_TestCase
     private function getTestUser()
     {
         $user = new User($this->userId, $this->userFirstName, $this->userLastName, $this->userUsername, $this->userUserInfos);
+
         return $user;
     }
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -18,7 +18,8 @@ class UserTest extends PHPUnit_Framework_TestCase
         'color' => '9f69e7',
         'profile' => [
             'avatar_hash' => 'ge3b51ca72de',
-            'current_status' => ':mountain_railway => riding a train',
+            'status_emoji' => ':mountain_railway:',
+            'status_text' => 'riding a train',
             'first_name' => 'Bobby',
             'last_name' => 'Tables',
             'real_name' => 'Bobby Tables',

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -16,7 +16,7 @@ class UserTest extends PHPUnit_Framework_TestCase
         'name' => 'bobby',
         'deleted' => false,
         'color' => '9f69e7',
-        'profile' =>  [
+        'profile' => [
             'avatar_hash' => 'ge3b51ca72de',
             'current_status' => ':mountain_railway => riding a train',
             'first_name' => 'Bobby',
@@ -32,12 +32,12 @@ class UserTest extends PHPUnit_Framework_TestCase
             'image_32' => 'https:\/\/...',
             'image_48' => 'https:\/\/...',
             'image_72' => 'https:\/\/...',
-            'image_192' => 'https:\/\/...'
+            'image_192' => 'https:\/\/...',
         ],
         'is_admin' => true,
         'is_owner' => true,
         'updated' => 1490054400,
-        'has_2fa' => true
+        'has_2fa' => true,
     ];
 
     private function getTestUser()


### PR DESCRIPTION
This add a new property to the User interface. The goal is to be give the drivers the possibility to store the raw user data, and get it back.

You can sent object or array, but it will always return an array.
We will need to edit the drivers to use this new property.

Here are some examples:

SlackRTM:
```
return new User(
    $matchingMessage->getSender(),
    $user->getFirstName(),
    $user->getLastName(),
    $user->getUsername(),
    $user->jsonSerialize() // or sympy $user, it will work too
);
```

Discord:
```
return new User(
    $matchingMessage->getSender(),
    $user->getFirstName(),
    $user->getLastName(),
    $user->getUsername(),
    $user
);
```

Facebook:
```
$profileData = json_decode($profileData->getContent());
$firstName = isset($profileData->first_name) ? $profileData->first_name : null;
$lastName = isset($profileData->last_name) ? $profileData->last_name : null;
return new User(
    $matchingMessage->getSender(),
    $firstName,
    $lastName,
    '',
    $profileData
);
```
