### PR TITLE
Image attachments fix

### DIFF
--- a/src/Mpociot/BotMan/Drivers/SlackDriver.php
+++ b/src/Mpociot/BotMan/Drivers/SlackDriver.php
@@ -214,7 +214,14 @@ class SlackDriver extends Driver
         } elseif ($message instanceof IncomingMessage) {
             $parameters['text'] = $message->getMessage();
             if (! is_null($message->getImage())) {
-                $parameters['attachments'] = json_encode(['image_url' => $message->getImage()]);
+                $parameters['attachments'] = json_encode(
+                    [
+                        [
+                            'title' => $message->getImage(),
+                            'image_url' => $message->getImage(),
+                        ]
+                    ]
+                );
             }
         } else {
             $parameters['text'] = $this->format($message);


### PR DESCRIPTION
Fixes #466.

The title attribute is mandatory for attachments, so with it images are shown correctly.