### PR TITLE
Accept exception handlers without closures

### DIFF
--- a/src/Traits/HandlesExceptions.php
+++ b/src/Traits/HandlesExceptions.php
@@ -12,9 +12,9 @@ trait HandlesExceptions
      * @param string $exception
      * @param callable $closure
      */
-    public function exception(string $exception, callable $closure)
+    public function exception(string $exception, $closure)
     {
-        $this->exceptionHandler->register($exception, $closure);
+        $this->exceptionHandler->register($exception, $this->getCallable($closure));
     }
 
     /**

--- a/tests/Exceptions/ExceptionTest.php
+++ b/tests/Exceptions/ExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan\tests;
 
+use BotMan\BotMan\Tests\Fixtures\TestClass;
 use Exception;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
@@ -64,5 +65,25 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
         });
 
         $botman->listen();
+    }
+
+    /** @test */
+    public function it_catches_exceptions_without_closures()
+    {
+        $botman = $this->getBot([
+            'sender' => 'UX12345',
+            'recipient' => 'general',
+            'message' => 'Hi Julia',
+        ]);
+
+        $botman->exception(Exception::class, TestClass::class.'@exceptionHandler');
+
+        $botman->hears('Hi Julia', function () {
+            throw new Exception('Whoops');
+        });
+
+        $botman->listen();
+
+	    $this->assertTrue(TestClass::$called);
     }
 }

--- a/tests/Exceptions/ExceptionTest.php
+++ b/tests/Exceptions/ExceptionTest.php
@@ -2,7 +2,6 @@
 
 namespace BotMan\BotMan\tests;
 
-use BotMan\BotMan\Tests\Fixtures\TestClass;
 use Exception;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
@@ -11,6 +10,7 @@ use BotMan\BotMan\BotManFactory;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Cache\ArrayCache;
 use BotMan\BotMan\Drivers\Tests\FakeDriver;
+use BotMan\BotMan\Tests\Fixtures\TestClass;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
 class ExceptionTest extends PHPUnit_Framework_TestCase
@@ -84,6 +84,6 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
 
         $botman->listen();
 
-	    $this->assertTrue(TestClass::$called);
+        $this->assertTrue(TestClass::$called);
     }
 }

--- a/tests/Fixtures/TestClass.php
+++ b/tests/Fixtures/TestClass.php
@@ -20,8 +20,9 @@ class TestClass
         self::$called = true;
     }
 
-    public function exceptionHandler($exception, $bot) {
-	    self::$called = true;
+    public function exceptionHandler($exception, $bot)
+    {
+        self::$called = true;
     }
 
     public function __invoke(BotMan $bot)

--- a/tests/Fixtures/TestClass.php
+++ b/tests/Fixtures/TestClass.php
@@ -20,6 +20,10 @@ class TestClass
         self::$called = true;
     }
 
+    public function exceptionHandler($exception, $bot) {
+	    self::$called = true;
+    }
+
     public function __invoke(BotMan $bot)
     {
         self::$called = true;


### PR DESCRIPTION
As title, accept `class@method` with exception handler, and not only closures.