### PR TITLE
Inherited exceptions handlers, custom Botman internal exceptions

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -2,8 +2,6 @@
 
 namespace BotMan\BotMan;
 
-use BotMan\BotMan\Exceptions\Core\BadMethodCallException;
-use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 use Closure;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Commands\Command;
@@ -13,6 +11,7 @@ use BotMan\BotMan\Traits\ProvidesStorage;
 use BotMan\BotMan\Interfaces\UserInterface;
 use BotMan\BotMan\Messages\Incoming\Answer;
 use BotMan\BotMan\Traits\HandlesExceptions;
+use BotMan\BotMan\Handlers\ExceptionHandler;
 use BotMan\BotMan\Interfaces\CacheInterface;
 use BotMan\BotMan\Messages\Attachments\File;
 use BotMan\BotMan\Interfaces\DriverInterface;
@@ -20,7 +19,6 @@ use BotMan\BotMan\Messages\Attachments\Audio;
 use BotMan\BotMan\Messages\Attachments\Image;
 use BotMan\BotMan\Messages\Attachments\Video;
 use BotMan\BotMan\Messages\Outgoing\Question;
-use BotMan\BotMan\Handlers\ExceptionHandler;
 use BotMan\BotMan\Interfaces\StorageInterface;
 use BotMan\BotMan\Traits\HandlesConversations;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +29,8 @@ use BotMan\BotMan\Interfaces\DriverEventInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 use BotMan\BotMan\Interfaces\ExceptionHandlerInterface;
+use BotMan\BotMan\Exceptions\Core\BadMethodCallException;
+use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 use BotMan\BotMan\Messages\Conversations\InlineConversation;
 
 /**
@@ -528,14 +528,14 @@ class BotMan
         return $this;
     }
 
-	/**
-	 * Low-level method to perform driver specific API requests.
-	 *
-	 * @param string $endpoint
-	 * @param array $additionalParameters
-	 * @return $this
-	 * @throws BadMethodCallException
-	 */
+    /**
+     * Low-level method to perform driver specific API requests.
+     *
+     * @param string $endpoint
+     * @param array $additionalParameters
+     * @return $this
+     * @throws BadMethodCallException
+     */
     public function sendRequest($endpoint, $additionalParameters = [])
     {
         $driver = $this->getDriver();
@@ -579,13 +579,13 @@ class BotMan
         return $this->reply($messages[array_rand($messages)]);
     }
 
-	/**
-	 * Make an action for an invokable controller.
-	 *
-	 * @param string $action
-	 * @return string
-	 * @throws UnexpectedValueException
-	 */
+    /**
+     * Make an action for an invokable controller.
+     *
+     * @param string $action
+     * @return string
+     * @throws UnexpectedValueException
+     */
     protected function makeInvokableAction($action)
     {
         if (! method_exists($action, '__invoke')) {
@@ -632,12 +632,12 @@ class BotMan
         return $this->message;
     }
 
-	/**
-	 * @param string $name
-	 * @param mixed $arguments
-	 * @return mixed
-	 * @throws BadMethodCallException
-	 */
+    /**
+     * @param string $name
+     * @param mixed $arguments
+     * @return mixed
+     * @throws BadMethodCallException
+     */
     public function __call($name, $arguments)
     {
         if (method_exists($this->getDriver(), $name)) {

--- a/src/Exceptions/Base/BotManException.php
+++ b/src/Exceptions/Base/BotManException.php
@@ -2,9 +2,8 @@
 
 namespace BotMan\BotMan\Exceptions\Base;
 
-
 use Exception;
 
-class BotManException extends Exception {
-
+class BotManException extends Exception
+{
 }

--- a/src/Exceptions/Base/BotManException.php
+++ b/src/Exceptions/Base/BotManException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BotMan\BotMan\Exceptions\Base;
+
+
+use Exception;
+
+class BotManException extends Exception {
+
+}

--- a/src/Exceptions/Base/DriverAttachmentException.php
+++ b/src/Exceptions/Base/DriverAttachmentException.php
@@ -1,0 +1,7 @@
+<?php
+namespace BotMan\BotMan\Exceptions\Base;
+
+
+class DriverAttachmentException extends DriverException {
+
+}

--- a/src/Exceptions/Base/DriverAttachmentException.php
+++ b/src/Exceptions/Base/DriverAttachmentException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace BotMan\BotMan\Exceptions\Base;
 
-
-class DriverAttachmentException extends DriverException {
-
+class DriverAttachmentException extends DriverException
+{
 }

--- a/src/Exceptions/Base/DriverException.php
+++ b/src/Exceptions/Base/DriverException.php
@@ -2,7 +2,6 @@
 
 namespace BotMan\BotMan\Exceptions\Base;
 
-
-class DriverException extends BotManException {
-
+class DriverException extends BotManException
+{
 }

--- a/src/Exceptions/Base/DriverException.php
+++ b/src/Exceptions/Base/DriverException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BotMan\BotMan\Exceptions\Base;
+
+
+class DriverException extends BotManException {
+
+}

--- a/src/Exceptions/Core/BadMethodCallException.php
+++ b/src/Exceptions/Core/BadMethodCallException.php
@@ -2,9 +2,8 @@
 
 namespace BotMan\BotMan\Exceptions\Core;
 
-
 use BotMan\BotMan\Exceptions\Base\BotManException;
 
-class BadMethodCallException extends BotManException {
-
+class BadMethodCallException extends BotManException
+{
 }

--- a/src/Exceptions/Core/BadMethodCallException.php
+++ b/src/Exceptions/Core/BadMethodCallException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BotMan\BotMan\Exceptions\Core;
+
+
+use BotMan\BotMan\Exceptions\Base\BotManException;
+
+class BadMethodCallException extends BotManException {
+
+}

--- a/src/Exceptions/Core/UnexpectedValueException.php
+++ b/src/Exceptions/Core/UnexpectedValueException.php
@@ -1,0 +1,8 @@
+<?php
+namespace BotMan\BotMan\Exceptions\Core;
+
+use BotMan\BotMan\Exceptions\Base\BotManException;
+
+class UnexpectedValueException extends BotManException {
+
+}

--- a/src/Exceptions/Core/UnexpectedValueException.php
+++ b/src/Exceptions/Core/UnexpectedValueException.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace BotMan\BotMan\Exceptions\Core;
 
 use BotMan\BotMan\Exceptions\Base\BotManException;
 
-class UnexpectedValueException extends BotManException {
-
+class UnexpectedValueException extends BotManException
+{
 }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -25,27 +25,28 @@ class ExceptionHandler implements ExceptionHandlerInterface
      */
     public function handleException($e, BotMan $bot)
     {
-		$class = get_class($e);
-    	$handler = $this->exceptions->get($class);
+        $class = get_class($e);
+        $handler = $this->exceptions->get($class);
 
-	    // Exact exception handler found, call it.
-	    if ($handler !== null) {
-		    call_user_func_array($handler, [$e, $bot]);
-		    return;
-	    }
+        // Exact exception handler found, call it.
+        if ($handler !== null) {
+            call_user_func_array($handler, [$e, $bot]);
 
-	    $parentExceptions = Collection::make(class_parents($class));
+            return;
+        }
 
-	    foreach ($parentExceptions as $exceptionClass) {
+        $parentExceptions = Collection::make(class_parents($class));
 
-	    	if ($this->exceptions->has($exceptionClass)) {
-			    call_user_func_array($this->exceptions->get($exceptionClass), [$e, $bot]);
-			    return;
-		    }
-	    }
+        foreach ($parentExceptions as $exceptionClass) {
+            if ($this->exceptions->has($exceptionClass)) {
+                call_user_func_array($this->exceptions->get($exceptionClass), [$e, $bot]);
 
-	    // No matching parent exception, throw the exception away
-	    throw $e;
+                return;
+            }
+        }
+
+        // No matching parent exception, throw the exception away
+        throw $e;
     }
 
     /**

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -2,8 +2,6 @@
 
 namespace BotMan\BotMan\tests;
 
-use BotMan\BotMan\Exceptions\Core\BadMethodCallException;
-use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
@@ -31,6 +29,8 @@ use BotMan\BotMan\Tests\Fixtures\TestMatchMiddleware;
 use BotMan\BotMan\Messages\Conversations\Conversation;
 use BotMan\BotMan\Tests\Fixtures\TestAdditionalDriver;
 use BotMan\BotMan\Tests\Fixtures\TestNoMatchMiddleware;
+use BotMan\BotMan\Exceptions\Core\BadMethodCallException;
+use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 
 /**
  * Class BotManTest.

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -2,6 +2,8 @@
 
 namespace BotMan\BotMan\tests;
 
+use BotMan\BotMan\Exceptions\Core\BadMethodCallException;
+use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
@@ -283,7 +285,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman->listen();
         $this->assertTrue(TestClass::$called);
 
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Invalid hears action: [stdClass]');
 
         $botman = $this->getBot([
@@ -1783,7 +1785,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $botman = $this->getBot([]);
         $botman->setDriver(new FakeDriver());
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $botman->sendRequest('foo', []);
     }
 

--- a/tests/Exceptions/ExceptionTest.php
+++ b/tests/Exceptions/ExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan\tests;
 
+use BotMan\BotMan\Exceptions\Base\BotManException;
 use Exception;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
@@ -86,4 +87,27 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue(TestClass::$called);
     }
+
+
+	/** @test */
+	public function it_catches_inherited_exceptions()
+	{
+		$botman = $this->getBot([
+			'sender' => 'UX12345',
+			'recipient' => 'general',
+			'message' => 'Hi Julia',
+		]);
+
+		$botman->exception(Exception::class, function (Exception $exception, $bot) {
+			$this->assertInstanceOf(BotManException::class, $exception);
+			$this->assertInstanceOf(BotMan::class, $bot);
+			$this->assertSame('Whoops', $exception->getMessage());
+		});
+
+		$botman->hears('Hi Julia', function () {
+			throw new BotManException('Whoops');
+		});
+
+		$botman->listen();
+	}
 }

--- a/tests/Storages/FileStorageTest.php
+++ b/tests/Storages/FileStorageTest.php
@@ -18,7 +18,9 @@ class FileStorageTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        exec('rm -rf '.__DIR__.'/../Fixtures/storage/*.json');
+        foreach (glob(__DIR__.'/../Fixtures/storage/*.json') as $file) {
+        	unlink($file);
+        }
     }
 
     /** @test */

--- a/tests/Storages/FileStorageTest.php
+++ b/tests/Storages/FileStorageTest.php
@@ -19,7 +19,7 @@ class FileStorageTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         foreach (glob(__DIR__.'/../Fixtures/storage/*.json') as $file) {
-        	unlink($file);
+            unlink($file);
         }
     }
 

--- a/tests/Storages/StorageTest.php
+++ b/tests/Storages/StorageTest.php
@@ -23,9 +23,9 @@ class StorageTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-	    foreach (glob(__DIR__.'/../Fixtures/storage/*.json') as $file) {
-		    unlink($file);
-	    }
+        foreach (glob(__DIR__.'/../Fixtures/storage/*.json') as $file) {
+            unlink($file);
+        }
     }
 
     /** @test */

--- a/tests/Storages/StorageTest.php
+++ b/tests/Storages/StorageTest.php
@@ -23,7 +23,9 @@ class StorageTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        exec('rm -rf '.__DIR__.'/../Fixtures/storage/*.json');
+	    foreach (glob(__DIR__.'/../Fixtures/storage/*.json') as $file) {
+		    unlink($file);
+	    }
     }
 
     /** @test */


### PR DESCRIPTION
This allow to catch exceptions by their inheritance chain. 
For example:
`Exception -> BotManException-> DriverException -> DriverAttachmentException`

If a handler for DriverAttachmentException is not found, it looks for a handler for DriverException, BotManException, and finally Exception. If a handler for one of this chain is not found, the exception will be thrown.