### PR TITLE
Fix say method to keep the previous state

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -465,13 +465,13 @@ class BotMan
      */
     public function say($message, $recipient, $driver = null, $additionalParameters = [])
     {
-	    $previousDriver = $this->driver;
-	    $previousMessage = $this->message;
+        $previousDriver = $this->driver;
+        $previousMessage = $this->message;
 
         if ($driver instanceof DriverInterface) {
-	        $this->setDriver($driver);
+            $this->setDriver($driver);
         } elseif (is_string($driver)) {
-	        $this->setDriver(DriverManager::loadFromName($driver, $this->config));
+            $this->setDriver(DriverManager::loadFromName($driver, $this->config));
         }
 
         $this->message = new IncomingMessage('', $recipient, '');

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -465,19 +465,20 @@ class BotMan
      */
     public function say($message, $recipient, $driver = null, $additionalParameters = [])
     {
-        if (is_null($driver)) {
-            $drivers = DriverManager::getConfiguredDrivers($this->config);
+	    $previousDriver = $this->driver;
+	    $previousMessage = $this->message;
+
+        if ($driver instanceof DriverInterface) {
+	        $this->setDriver($driver);
         } elseif (is_string($driver)) {
-            $drivers = [DriverManager::loadFromName($driver, $this->config)];
-        } else {
-            $drivers = [$driver];
+	        $this->setDriver(DriverManager::loadFromName($driver, $this->config));
         }
 
-        foreach ($drivers as $driver) {
-            $this->message = new IncomingMessage('', $recipient, '');
-            $this->setDriver($driver);
-            $this->reply($message, $additionalParameters);
-        }
+        $this->message = new IncomingMessage('', $recipient, '');
+        $this->reply($message, $additionalParameters);
+
+        $this->message = $previousMessage;
+        $this->driver = $previousDriver;
 
         return $this;
     }

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan;
 
+use BotMan\BotMan\Exceptions\Base\BotManException;
 use Closure;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Commands\Command;
@@ -456,15 +457,20 @@ class BotMan
         return DriverManager::verifyServices($this->config);
     }
 
-    /**
-     * @param string|Question $message
-     * @param string|array $recipient
-     * @param DriverInterface|null $driver
-     * @param array $additionalParameters
-     * @return $this
-     */
+	/**
+	 * @param string|Question $message
+	 * @param string|array $recipient
+	 * @param DriverInterface|null $driver
+	 * @param array $additionalParameters
+	 * @return $this
+	 * @throws BotManException
+	 */
     public function say($message, $recipient, $driver = null, $additionalParameters = [])
     {
+    	if ($driver === null && $this->driver === null) {
+    		throw new BotManException('The current driver can\'t be NULL');
+	    }
+
         $previousDriver = $this->driver;
         $previousMessage = $this->message;
 

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -2,7 +2,6 @@
 
 namespace BotMan\BotMan;
 
-use BotMan\BotMan\Exceptions\Base\BotManException;
 use Closure;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Commands\Command;
@@ -26,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use BotMan\BotMan\Commands\ConversationManager;
 use BotMan\BotMan\Middleware\MiddlewareManager;
 use BotMan\BotMan\Messages\Attachments\Location;
+use BotMan\BotMan\Exceptions\Base\BotManException;
 use BotMan\BotMan\Interfaces\DriverEventInterface;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
@@ -457,19 +457,19 @@ class BotMan
         return DriverManager::verifyServices($this->config);
     }
 
-	/**
-	 * @param string|Question $message
-	 * @param string|array $recipient
-	 * @param DriverInterface|null $driver
-	 * @param array $additionalParameters
-	 * @return $this
-	 * @throws BotManException
-	 */
+    /**
+     * @param string|Question $message
+     * @param string|array $recipient
+     * @param DriverInterface|null $driver
+     * @param array $additionalParameters
+     * @return $this
+     * @throws BotManException
+     */
     public function say($message, $recipient, $driver = null, $additionalParameters = [])
     {
-    	if ($driver === null && $this->driver === null) {
-    		throw new BotManException('The current driver can\'t be NULL');
-	    }
+        if ($driver === null && $this->driver === null) {
+            throw new BotManException('The current driver can\'t be NULL');
+        }
 
         $previousDriver = $this->driver;
         $previousMessage = $this->message;

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -2,7 +2,6 @@
 
 namespace BotMan\BotMan\tests;
 
-use BotMan\BotMan\Exceptions\Base\BotManException;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
@@ -24,6 +23,7 @@ use BotMan\BotMan\Tests\Fixtures\TestFallback;
 use BotMan\BotMan\Middleware\MiddlewareManager;
 use BotMan\BotMan\Messages\Attachments\Location;
 use BotMan\BotMan\Tests\Fixtures\TestMiddleware;
+use BotMan\BotMan\Exceptions\Base\BotManException;
 use BotMan\BotMan\Tests\Fixtures\TestConversation;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Tests\Fixtures\TestMatchMiddleware;
@@ -1298,7 +1298,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
-	    $this->expectException(BotManException::class);
+        $this->expectException(BotManException::class);
         $botman->say('foo', 'channel');
     }
 

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -1271,7 +1271,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function it_can_originate_messages_with_configured_drivers()
+    public function it_can_originate_messages_with_configured_driver()
     {
         $driver = m::mock(NullDriver::class);
         $driver->shouldReceive('buildServicePayload')
@@ -1282,11 +1282,8 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $driver->shouldReceive('sendPayload')
             ->once();
 
-        $mock = \Mockery::mock('alias:BotMan\BotMan\Drivers\DriverManager');
-        $mock->shouldReceive('getConfiguredDrivers')
-            ->andReturn([$driver]);
-
         $botman = m::mock(BotMan::class)->makePartial();
+        $botman->setDriver($driver);
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
         $botman->say('foo', 'channel');
     }

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\BotMan\tests;
 
+use BotMan\BotMan\Exceptions\Base\BotManException;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
@@ -1285,6 +1286,19 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->setDriver($driver);
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
+        $botman->say('foo', 'channel');
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function it_throws_an_exception_with_no_drivers()
+    {
+        $botman = m::mock(BotMan::class)->makePartial();
+        $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
+	    $this->expectException(BotManException::class);
         $botman->say('foo', 'channel');
     }
 


### PR DESCRIPTION
This will keep the previous message and driver after the call of the say method.