### PR TITLE
Add conversation message to value as well

### DIFF
--- a/src/Drivers/Tests/FakeDriver.php
+++ b/src/Drivers/Tests/FakeDriver.php
@@ -102,7 +102,7 @@ class FakeDriver implements DriverInterface, VerifiesService
 
     public function getConversationAnswer(IncomingMessage $message)
     {
-        $answer = Answer::create($message->getText())->setMessage($message);
+        $answer = Answer::create($message->getText())->setMessage($message)->setValue($message->getText());
         $answer->setInteractiveReply($this->isInteractiveMessageReply);
 
         return $answer;


### PR DESCRIPTION
This PR adds the fake conversation message text to the value too. This makes it possible to test for the value too in the BotMan tests.