### PR TITLE
User available drivers instead of configured ones for verify

### DIFF
--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -144,7 +144,8 @@ class DriverManager
     public static function verifyServices(array $config, Request $request = null)
     {
         $request = (isset($request)) ? $request : Request::createFromGlobals();
-        foreach (self::getConfiguredDrivers($config) as $driver) {
+        foreach (self::getAvailableDrivers() as $driver) {
+            $driver = new $driver(Request::createFromGlobals(), $config, new Curl());
             if ($driver instanceof VerifiesService) {
                 return $driver->verifyRequest($request);
             }

--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -145,7 +145,7 @@ class DriverManager
     {
         $request = (isset($request)) ? $request : Request::createFromGlobals();
         foreach (self::getAvailableDrivers() as $driver) {
-            $driver = new $driver(Request::createFromGlobals(), $config, new Curl());
+            $driver = new $driver($request, $config, new Curl());
             if ($driver instanceof VerifiesService) {
                 return $driver->verifyRequest($request);
             }


### PR DESCRIPTION
With Slack we need to verify events without a Slack token, so we need to verify it while the driver is not "configured". This PR uses the available drivers for that instead of the configured ones.