### PR TITLE
Feature - cache message user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.0.3]
+### Fixed
+- Use available drivers instead of configured ones for verification because of Slack events verification
+
 ## [2.0.2]
 ### Added
 - Drivers can have a method called `additionalDrivers` to simplify manual driver loading, when not using BotMan studio.

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -39,9 +39,7 @@ use BotMan\BotMan\Messages\Conversations\InlineConversation;
  */
 class BotMan
 {
-    use ProvidesStorage,
-        HandlesConversations,
-        HandlesExceptions;
+    use ProvidesStorage, HandlesConversations, HandlesExceptions;
 
     /** @var \Illuminate\Support\Collection */
     protected $event;
@@ -63,6 +61,7 @@ class BotMan
 
     /**
      * IncomingMessage service events.
+     *
      * @var array
      */
     protected $events = [];
@@ -70,6 +69,7 @@ class BotMan
     /**
      * The fallback message to use, if no match
      * could be heard.
+     *
      * @var callable|null
      */
     protected $fallbackMessage;
@@ -112,6 +112,7 @@ class BotMan
 
     /**
      * BotMan constructor.
+     *
      * @param CacheInterface $cache
      * @param DriverInterface $driver
      * @param array $config
@@ -211,7 +212,14 @@ class BotMan
      */
     public function getUser()
     {
-        return $this->getDriver()->getUser($this->getMessage());
+        if ($user = $this->cache->get('user_'.$this->driverName.'_'.$this->getMessage()->getSender())) {
+            return $user;
+        }
+
+        $user = $this->getDriver()->getUser($this->getMessage());
+        $this->cache->put('user_'.$this->driverName.'_'.$user->getId(), $user, 30);
+
+        return $user;
     }
 
     /**
@@ -230,9 +238,9 @@ class BotMan
     }
 
     /**
-     * @param string $pattern the pattern to listen for
+     * @param string $pattern          the pattern to listen for
      * @param Closure|string $callback the callback to execute. Either a closure or a Class@method notation
-     * @param string $in the channel type to listen to (either direct message or public channel)
+     * @param string $in               the channel type to listen to (either direct message or public channel)
      * @return Command
      */
     public function hears($pattern, $callback, $in = null)
@@ -390,7 +398,8 @@ class BotMan
      */
     protected function callMatchingMessages()
     {
-        $matchingMessages = $this->conversationManager->getMatchingMessages($this->getMessages(), $this->middleware, $this->getConversationAnswer(), $this->getDriver());
+        $matchingMessages = $this->conversationManager->getMatchingMessages($this->getMessages(), $this->middleware,
+            $this->getConversationAnswer(), $this->getDriver());
 
         foreach ($matchingMessages as $matchingMessage) {
             $this->command = $matchingMessage->getCommand();
@@ -401,25 +410,16 @@ class BotMan
             // Set the message first, so it's available for middlewares
             $this->message = $matchingMessage->getMessage();
 
-            $this->message = $this->middleware->applyMiddleware('heard', $matchingMessage->getMessage(), $this->command->getMiddleware());
+            $this->message = $this->middleware->applyMiddleware('heard', $matchingMessage->getMessage(),
+                $this->command->getMiddleware());
             $parameterNames = $this->compileParameterNames($this->command->getPattern());
 
             $parameters = $matchingMessage->getMatches();
             if (count($parameterNames) !== count($parameters)) {
-                $parameters = array_merge(
-                    //First, all named parameters (eg. function ($a, $b, $c))
-                    array_filter(
-                        $parameters,
-                        'is_string',
-                        ARRAY_FILTER_USE_KEY
-                    ),
+                $parameters = array_merge(//First, all named parameters (eg. function ($a, $b, $c))
+                    array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY),
                     //Then, all other unsorted parameters (regex non named results)
-                    array_filter(
-                        $parameters,
-                        'is_integer',
-                        ARRAY_FILTER_USE_KEY
-                    )
-                );
+                    array_filter($parameters, 'is_integer', ARRAY_FILTER_USE_KEY));
             }
 
             $this->matches = $parameters;
@@ -562,7 +562,8 @@ class BotMan
     {
         $message = is_string($message) ? OutgoingMessage::create($message) : $message;
 
-        return $this->sendPayload($this->getDriver()->buildServicePayload($message, $this->message, $additionalParameters));
+        return $this->sendPayload($this->getDriver()->buildServicePayload($message, $this->message,
+            $additionalParameters));
     }
 
     /**
@@ -578,6 +579,7 @@ class BotMan
 
     /**
      * Return a random message.
+     *
      * @param array $messages
      * @return $this
      */
@@ -596,9 +598,7 @@ class BotMan
     protected function makeInvokableAction($action)
     {
         if (! method_exists($action, '__invoke')) {
-            throw new UnexpectedValueException(sprintf(
-                'Invalid hears action: [%s]', $action
-            ));
+            throw new UnexpectedValueException(sprintf('Invalid hears action: [%s]', $action));
         }
 
         return $action.'@__invoke';

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -212,12 +212,12 @@ class BotMan
      */
     public function getUser()
     {
-        if ($user = $this->cache->get('user_'.$this->driverName.'_'.$this->getMessage()->getSender())) {
+        if ($user = $this->cache->get('user_'.$this->driver->getName().'_'.$this->getMessage()->getSender())) {
             return $user;
         }
 
         $user = $this->getDriver()->getUser($this->getMessage());
-        $this->cache->put('user_'.$this->driverName.'_'.$user->getId(), $user, 30);
+        $this->cache->put('user_'.$this->driver->getName().'_'.$user->getId(), $user, $this->config['user_cache_time'] ?? 30);
 
         return $user;
     }

--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -39,7 +39,9 @@ use BotMan\BotMan\Messages\Conversations\InlineConversation;
  */
 class BotMan
 {
-    use ProvidesStorage, HandlesConversations, HandlesExceptions;
+    use ProvidesStorage,
+        HandlesConversations,
+        HandlesExceptions;
 
     /** @var \Illuminate\Support\Collection */
     protected $event;
@@ -61,7 +63,6 @@ class BotMan
 
     /**
      * IncomingMessage service events.
-     *
      * @var array
      */
     protected $events = [];
@@ -69,7 +70,6 @@ class BotMan
     /**
      * The fallback message to use, if no match
      * could be heard.
-     *
      * @var callable|null
      */
     protected $fallbackMessage;
@@ -112,7 +112,6 @@ class BotMan
 
     /**
      * BotMan constructor.
-     *
      * @param CacheInterface $cache
      * @param DriverInterface $driver
      * @param array $config
@@ -238,9 +237,9 @@ class BotMan
     }
 
     /**
-     * @param string $pattern          the pattern to listen for
+     * @param string $pattern the pattern to listen for
      * @param Closure|string $callback the callback to execute. Either a closure or a Class@method notation
-     * @param string $in               the channel type to listen to (either direct message or public channel)
+     * @param string $in the channel type to listen to (either direct message or public channel)
      * @return Command
      */
     public function hears($pattern, $callback, $in = null)
@@ -398,8 +397,7 @@ class BotMan
      */
     protected function callMatchingMessages()
     {
-        $matchingMessages = $this->conversationManager->getMatchingMessages($this->getMessages(), $this->middleware,
-            $this->getConversationAnswer(), $this->getDriver());
+        $matchingMessages = $this->conversationManager->getMatchingMessages($this->getMessages(), $this->middleware, $this->getConversationAnswer(), $this->getDriver());
 
         foreach ($matchingMessages as $matchingMessage) {
             $this->command = $matchingMessage->getCommand();
@@ -410,16 +408,25 @@ class BotMan
             // Set the message first, so it's available for middlewares
             $this->message = $matchingMessage->getMessage();
 
-            $this->message = $this->middleware->applyMiddleware('heard', $matchingMessage->getMessage(),
-                $this->command->getMiddleware());
+            $this->message = $this->middleware->applyMiddleware('heard', $matchingMessage->getMessage(), $this->command->getMiddleware());
             $parameterNames = $this->compileParameterNames($this->command->getPattern());
 
             $parameters = $matchingMessage->getMatches();
             if (count($parameterNames) !== count($parameters)) {
-                $parameters = array_merge(//First, all named parameters (eg. function ($a, $b, $c))
-                    array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY),
+                $parameters = array_merge(
+                    //First, all named parameters (eg. function ($a, $b, $c))
+                    array_filter(
+                        $parameters,
+                        'is_string',
+                        ARRAY_FILTER_USE_KEY
+                    ),
                     //Then, all other unsorted parameters (regex non named results)
-                    array_filter($parameters, 'is_integer', ARRAY_FILTER_USE_KEY));
+                    array_filter(
+                        $parameters,
+                        'is_integer',
+                        ARRAY_FILTER_USE_KEY
+                    )
+                );
             }
 
             $this->matches = $parameters;
@@ -562,8 +569,7 @@ class BotMan
     {
         $message = is_string($message) ? OutgoingMessage::create($message) : $message;
 
-        return $this->sendPayload($this->getDriver()->buildServicePayload($message, $this->message,
-            $additionalParameters));
+        return $this->sendPayload($this->getDriver()->buildServicePayload($message, $this->message, $additionalParameters));
     }
 
     /**
@@ -579,7 +585,6 @@ class BotMan
 
     /**
      * Return a random message.
-     *
      * @param array $messages
      * @return $this
      */
@@ -598,7 +603,9 @@ class BotMan
     protected function makeInvokableAction($action)
     {
         if (! method_exists($action, '__invoke')) {
-            throw new UnexpectedValueException(sprintf('Invalid hears action: [%s]', $action));
+            throw new UnexpectedValueException(sprintf(
+                'Invalid hears action: [%s]', $action
+            ));
         }
 
         return $action.'@__invoke';

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -42,7 +42,7 @@ trait HandlesConversations
             'additionalParameters' => serialize($additionalParameters),
             'next' => $this->prepareCallbacks($next),
             'time' => microtime(),
-        ], isset($this->config['conversation_cache_time']) ? $this->config['conversation_cache_time'] : 30);
+        ], $this->config['conversation_cache_time'] ?? 30);
     }
 
     /**

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -574,12 +574,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
         ];
 
         foreach ($botmans as $botman) {
-            $botman->hears('(I am|You are) {name} (the|a) {attribute}', function ($bot, $name, $attribute) use (&$called) {
-                $called = true;
+            $botman->hears('(I am|You are) {name} (the|a) {attribute}',
+                function ($bot, $name, $attribute) use (&$called) {
+                    $called = true;
 
-                $this->assertSame('Gandalf', $name);
-                $this->assertSame('grey', $attribute);
-            });
+                    $this->assertSame('Gandalf', $name);
+                    $this->assertSame('grey', $attribute);
+                });
         }
 
         $botman->listen();
@@ -657,12 +658,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman->listen();
 
         $conversation = m::mock(TestConversation::class);
-        $conversation->shouldReceive('setBot')
-            ->once()
-            ->with($botman);
+        $conversation->shouldReceive('setBot')->once()->with($botman);
 
-        $conversation->shouldReceive('run')
-            ->once();
+        $conversation->shouldReceive('run')->once();
 
         $botman->startConversation($conversation);
     }
@@ -1217,19 +1215,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_originate_messages_with_given_driver()
     {
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
-            });
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
+        });
+        $driver->shouldReceive('sendPayload')->once();
 
         $mock = \Mockery::mock('alias:BotMan\BotMan\Drivers\DriverManager');
-        $mock->shouldReceive('loadFromName')
-            ->once()
-            ->with(FakeDriver::class, [])
-            ->andReturn($driver);
+        $mock->shouldReceive('loadFromName')->once()->with(FakeDriver::class, [])->andReturn($driver);
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
@@ -1248,19 +1240,15 @@ class BotManTest extends PHPUnit_Framework_TestCase
         ];
 
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) use ($additionalParameters) {
-                return $message->getText() === 'foo' && $match->getSender() === '1234567890' && $arguments === $additionalParameters;
-            });
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) use (
+            $additionalParameters
+        ) {
+            return $message->getText() === 'foo' && $match->getSender() === '1234567890' && $arguments === $additionalParameters;
+        });
+        $driver->shouldReceive('sendPayload')->once();
 
         $mock = \Mockery::mock('alias:BotMan\BotMan\Drivers\DriverManager');
-        $mock->shouldReceive('loadFromName')
-            ->once()
-            ->with('NullDriver', [])
-            ->andReturn($driver);
+        $mock->shouldReceive('loadFromName')->once()->with('NullDriver', [])->andReturn($driver);
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
@@ -1275,13 +1263,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_originate_messages_with_configured_driver()
     {
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
-            });
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
+        });
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->setDriver($driver);
@@ -1306,10 +1291,8 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_use_custom_drivers()
     {
         $driver = m::mock(TestDriver::class);
-        $driver->shouldReceive('buildServicePayload')
-            ->once();
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('buildServicePayload')->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         DriverManager::loadDriver(TestDriver::class);
 
@@ -1326,9 +1309,8 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_passes_unknown_methods_to_the_driver()
     {
         $driver = m::mock(TestDriver::class);
-        $driver->shouldReceive('dummyMethod')
-            ->once()
-            ->with('bar', 'baz', m::type(IncomingMessage::class), m::type(BotMan::class));
+        $driver->shouldReceive('dummyMethod')->once()->with('bar', 'baz', m::type(IncomingMessage::class),
+            m::type(BotMan::class));
 
         DriverManager::loadDriver(TestDriver::class);
 
@@ -1360,17 +1342,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1390,20 +1368,15 @@ class BotManTest extends PHPUnit_Framework_TestCase
          */
         $botman = $this->getBot([]);
 
-        $driver->shouldReceive('getConversationAnswer')
-            ->andReturn(Answer::create('repeat'));
+        $driver->shouldReceive('getConversationAnswer')->andReturn(Answer::create('repeat'));
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('repeat', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('repeat', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman->setDriver($driver);
 
@@ -1415,17 +1388,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1445,20 +1414,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
          */
         $botman = $this->getBot([]);
 
-        $driver->shouldReceive('getConversationAnswer')
-            ->andReturn(Answer::create('repeat_modified'));
+        $driver->shouldReceive('getConversationAnswer')->andReturn(Answer::create('repeat_modified'));
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('repeat_modified', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([
+            new IncomingMessage('repeat_modified', 'UX12345', 'general')
+        ]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a modified test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a modified test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman->setDriver($driver);
 
@@ -1547,17 +1513,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1618,17 +1580,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1689,17 +1647,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')
-            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')
-            ->once()
-            ->withArgs(function ($message, $match, $arguments) {
-                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-            });
+        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
+            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+        });
 
-        $driver->shouldReceive('sendPayload')
-            ->once();
+        $driver->shouldReceive('sendPayload')->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1813,10 +1767,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')
-            ->andReturn([
-                $message,
-            ]);
+        $driver->shouldReceive('getMessages')->andReturn([
+            $message,
+        ]);
 
         $botman->setDriver($driver);
 
@@ -1842,10 +1795,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')
-            ->andReturn([
-                $message,
-            ]);
+        $driver->shouldReceive('getMessages')->andReturn([
+            $message,
+        ]);
 
         $botman->setDriver($driver);
 
@@ -1871,10 +1823,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')
-            ->andReturn([
-                $message,
-            ]);
+        $driver->shouldReceive('getMessages')->andReturn([
+            $message,
+        ]);
 
         $botman->setDriver($driver);
 
@@ -1902,10 +1853,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')
-            ->andReturn([
-                $message,
-            ]);
+        $driver->shouldReceive('getMessages')->andReturn([
+            $message,
+        ]);
 
         $botman->setDriver($driver);
 
@@ -1916,5 +1866,25 @@ class BotManTest extends PHPUnit_Framework_TestCase
         });
         $botman->listen();
         $this->assertTrue($called);
+    }
+
+    /** @test */
+    public function it_can_cache_the_user()
+    {
+        $user = null;
+        $driverName = null;
+
+        $botman = $this->getBot([
+            'sender' => 'UX12345',
+            'recipient' => 'general',
+            'message' => 'Foo',
+        ]);
+
+        $botman->hears('Foo', function ($bot) use (&$user, &$driverName) {
+            $user = $bot->getUser();
+            $driverName = $bot->getDriver()->getName();
+        });
+        $botman->listen();
+        $this->assertEquals($user, $this->cache->get('user_'.$driverName.'_UX12345'));
     }
 }

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -574,13 +574,12 @@ class BotManTest extends PHPUnit_Framework_TestCase
         ];
 
         foreach ($botmans as $botman) {
-            $botman->hears('(I am|You are) {name} (the|a) {attribute}',
-                function ($bot, $name, $attribute) use (&$called) {
-                    $called = true;
+            $botman->hears('(I am|You are) {name} (the|a) {attribute}', function ($bot, $name, $attribute) use (&$called) {
+                $called = true;
 
-                    $this->assertSame('Gandalf', $name);
-                    $this->assertSame('grey', $attribute);
-                });
+                $this->assertSame('Gandalf', $name);
+                $this->assertSame('grey', $attribute);
+            });
         }
 
         $botman->listen();
@@ -658,9 +657,12 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman->listen();
 
         $conversation = m::mock(TestConversation::class);
-        $conversation->shouldReceive('setBot')->once()->with($botman);
+        $conversation->shouldReceive('setBot')
+            ->once()
+            ->with($botman);
 
-        $conversation->shouldReceive('run')->once();
+        $conversation->shouldReceive('run')
+            ->once();
 
         $botman->startConversation($conversation);
     }
@@ -1215,13 +1217,19 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_originate_messages_with_given_driver()
     {
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
-        });
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
+            });
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $mock = \Mockery::mock('alias:BotMan\BotMan\Drivers\DriverManager');
-        $mock->shouldReceive('loadFromName')->once()->with(FakeDriver::class, [])->andReturn($driver);
+        $mock->shouldReceive('loadFromName')
+            ->once()
+            ->with(FakeDriver::class, [])
+            ->andReturn($driver);
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
@@ -1240,15 +1248,19 @@ class BotManTest extends PHPUnit_Framework_TestCase
         ];
 
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) use (
-            $additionalParameters
-        ) {
-            return $message->getText() === 'foo' && $match->getSender() === '1234567890' && $arguments === $additionalParameters;
-        });
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) use ($additionalParameters) {
+                return $message->getText() === 'foo' && $match->getSender() === '1234567890' && $arguments === $additionalParameters;
+            });
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $mock = \Mockery::mock('alias:BotMan\BotMan\Drivers\DriverManager');
-        $mock->shouldReceive('loadFromName')->once()->with('NullDriver', [])->andReturn($driver);
+        $mock->shouldReceive('loadFromName')
+            ->once()
+            ->with('NullDriver', [])
+            ->andReturn($driver);
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->middleware = m::mock(MiddlewareManager::class)->makePartial();
@@ -1263,10 +1275,13 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_originate_messages_with_configured_driver()
     {
         $driver = m::mock(NullDriver::class);
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
-        });
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'foo' && $match->getSender() === 'channel' && $arguments === [];
+            });
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = m::mock(BotMan::class)->makePartial();
         $botman->setDriver($driver);
@@ -1291,8 +1306,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_can_use_custom_drivers()
     {
         $driver = m::mock(TestDriver::class);
-        $driver->shouldReceive('buildServicePayload')->once();
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('buildServicePayload')
+            ->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         DriverManager::loadDriver(TestDriver::class);
 
@@ -1309,8 +1326,9 @@ class BotManTest extends PHPUnit_Framework_TestCase
     public function it_passes_unknown_methods_to_the_driver()
     {
         $driver = m::mock(TestDriver::class);
-        $driver->shouldReceive('dummyMethod')->once()->with('bar', 'baz', m::type(IncomingMessage::class),
-            m::type(BotMan::class));
+        $driver->shouldReceive('dummyMethod')
+            ->once()
+            ->with('bar', 'baz', m::type(IncomingMessage::class), m::type(BotMan::class));
 
         DriverManager::loadDriver(TestDriver::class);
 
@@ -1342,13 +1360,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1368,15 +1390,20 @@ class BotManTest extends PHPUnit_Framework_TestCase
          */
         $botman = $this->getBot([]);
 
-        $driver->shouldReceive('getConversationAnswer')->andReturn(Answer::create('repeat'));
+        $driver->shouldReceive('getConversationAnswer')
+            ->andReturn(Answer::create('repeat'));
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('repeat', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('repeat', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman->setDriver($driver);
 
@@ -1388,13 +1415,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
     {
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1414,17 +1445,20 @@ class BotManTest extends PHPUnit_Framework_TestCase
          */
         $botman = $this->getBot([]);
 
-        $driver->shouldReceive('getConversationAnswer')->andReturn(Answer::create('repeat_modified'));
+        $driver->shouldReceive('getConversationAnswer')
+            ->andReturn(Answer::create('repeat_modified'));
 
-        $driver->shouldReceive('getMessages')->andReturn([
-            new IncomingMessage('repeat_modified', 'UX12345', 'general'),
-        ]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('repeat_modified', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a modified test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a modified test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman->setDriver($driver);
 
@@ -1513,13 +1547,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1580,13 +1618,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1647,13 +1689,17 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $called = false;
         $driver = m::mock(NullDriver::class)->makePartial();
 
-        $driver->shouldReceive('getMessages')->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([new IncomingMessage('Hi Julia', 'UX12345', 'general')]);
 
-        $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {
-            return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
-        });
+        $driver->shouldReceive('buildServicePayload')
+            ->once()
+            ->withArgs(function ($message, $match, $arguments) {
+                return $message->getText() === 'This is a test question' && ($match instanceof IncomingMessage) && $arguments === [];
+            });
 
-        $driver->shouldReceive('sendPayload')->once();
+        $driver->shouldReceive('sendPayload')
+            ->once();
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -1767,9 +1813,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')->andReturn([
-            $message,
-        ]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([
+                $message,
+            ]);
 
         $botman->setDriver($driver);
 
@@ -1795,9 +1842,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')->andReturn([
-            $message,
-        ]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([
+                $message,
+            ]);
 
         $botman->setDriver($driver);
 
@@ -1823,9 +1871,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')->andReturn([
-            $message,
-        ]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([
+                $message,
+            ]);
 
         $botman->setDriver($driver);
 
@@ -1853,9 +1902,10 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $botman = $this->getBot([]);
 
         $driver = m::mock(FakeDriver::class)->makePartial();
-        $driver->shouldReceive('getMessages')->andReturn([
-            $message,
-        ]);
+        $driver->shouldReceive('getMessages')
+            ->andReturn([
+                $message,
+            ]);
 
         $botman->setDriver($driver);
 

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -1417,7 +1417,7 @@ class BotManTest extends PHPUnit_Framework_TestCase
         $driver->shouldReceive('getConversationAnswer')->andReturn(Answer::create('repeat_modified'));
 
         $driver->shouldReceive('getMessages')->andReturn([
-            new IncomingMessage('repeat_modified', 'UX12345', 'general')
+            new IncomingMessage('repeat_modified', 'UX12345', 'general'),
         ]);
 
         $driver->shouldReceive('buildServicePayload')->once()->withArgs(function ($message, $match, $arguments) {


### PR DESCRIPTION
This PR will cache the user received from the drivers `getUser` method. This is especially helpful for Facebook, because it will trigger an API call every time. What do you think about it @mpociot ?