### PR TITLE
Fix composer.json scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "phpunit",
         "cs": "php-cs-fixer fix"
     }
 }


### PR DESCRIPTION
https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands
> Note: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the phpunit binary is actually in vendor/bin/phpunit or bin/phpunit it will be found and executed.