### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 7.0
   - 7.1
 
+before_install:
+  - pip install --user codecov
+  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
 before_script:
   - travis_retry composer self-update --preview
   - travis_retry composer install --prefer-dist --no-interaction
@@ -14,10 +18,6 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
-
-before_install:
-  - pip install --user codecov
-  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 after_success:
   - codecov


### PR DESCRIPTION
Rearrange statements to match actual execution order on travis.

```
$ pip install --user codecov
before_install.2
0.02s$ echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
before_script.1
0.78s$ travis_retry composer self-update --preview
You are already using composer version 1.5.2 (preview channel).
before_script.2
64.84s$ travis_retry composer install --prefer-dist --no-interaction
before_script.3
0.01s$ sudo redis-server /etc/redis/redis.conf --port 6380 --requirepass 'secret'
9.94s$ vendor/bin/phpunit --coverage-clover=coverage.xml
```

Cheers