### PR TITLE
fix Laravel autodiscovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.1-dev"
-        }
-    },
-    "extras": {
+        },
         "laravel": {
             "providers": [
                 "BotMan\\BotMan\\BotManServiceProvider"


### PR DESCRIPTION
when I installed the package, noticed autodiscovery wasn't working for me.  after digging saw that it was put in `extras` when it should be in `extra`.