### PR TITLE
Conversation cache time can be set for specific conversation to override the default value

### DIFF
--- a/src/Messages/Conversations/Conversation.php
+++ b/src/Messages/Conversations/Conversation.php
@@ -176,6 +176,15 @@ abstract class Conversation
     }
 
     /**
+     * Override default conversation cache time (only for this conversation).
+     * @return mixed
+     */
+    public function getConversationCacheTime()
+    {
+        return $this->cacheTime ?? null;
+    }
+
+    /**
      * @return mixed
      */
     abstract public function run();

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -44,7 +44,7 @@ trait HandlesConversations
             'additionalParameters' => serialize($additionalParameters),
             'next' => $this->prepareCallbacks($next),
             'time' => microtime(),
-        ], $conversation_cache_time ?? $this->config['conversation_cache_time'] ?? 30);
+        ], $conversation_cache_time ?? $this->config['config']['conversation_cache_time'] ?? 30);
     }
 
     /**

--- a/src/Traits/HandlesConversations.php
+++ b/src/Traits/HandlesConversations.php
@@ -36,13 +36,15 @@ trait HandlesConversations
      */
     public function storeConversation(Conversation $instance, $next, $question = null, $additionalParameters = [])
     {
+        $conversation_cache_time = $instance->getConversationCacheTime();
+
         $this->cache->put($this->message->getConversationIdentifier(), [
             'conversation' => $instance,
             'question' => serialize($question),
             'additionalParameters' => serialize($additionalParameters),
             'next' => $this->prepareCallbacks($next),
             'time' => microtime(),
-        ], $this->config['conversation_cache_time'] ?? 30);
+        ], $conversation_cache_time ?? $this->config['conversation_cache_time'] ?? 30);
     }
 
     /**


### PR DESCRIPTION
### USAGE
```
class TestConversation extends Conversation
{
   /**
     * How long should this conversation be cached (in minutes)
     */
   $protected $cacheTime = 5;

    /**
     * @return mixed
     */
    public function run()
    {
        ...
    }
}
```

This allows to set different cache time for different conversation. For example, when originating conversation developer can not be sure that user will respond immediately and thus want to set longer cache time