### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/AnswerTest.php
+++ b/tests/AnswerTest.php
@@ -2,11 +2,11 @@
 
 namespace BotMan\BotMan\tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Messages\Incoming\Answer;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class AnswerTest extends PHPUnit_Framework_TestCase
+class AnswerTest extends TestCase
 {
     /** @test */
     public function it_can_be_created()

--- a/tests/BotManConversationTest.php
+++ b/tests/BotManConversationTest.php
@@ -4,7 +4,7 @@ namespace BotMan\BotMan\tests;
 
 use Mockery as m;
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Cache\ArrayCache;
 use BotMan\BotMan\Drivers\DriverManager;
@@ -18,7 +18,7 @@ use BotMan\BotMan\Tests\Fixtures\TestConversation;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Tests\Fixtures\TestDataConversation;
 
-class BotManConversationTest extends PHPUnit_Framework_TestCase
+class BotManConversationTest extends TestCase
 {
     /** @var BotMan */
     private $botman;

--- a/tests/BotManDriverEventTest.php
+++ b/tests/BotManDriverEventTest.php
@@ -3,14 +3,14 @@
 namespace BotMan\BotMan\Tests;
 
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Drivers\DriverManager;
 use BotMan\BotMan\Drivers\Tests\FakeDriver;
 use BotMan\BotMan\Drivers\Tests\ProxyDriver;
 use BotMan\BotMan\Interfaces\DriverEventInterface;
 
-class BotManDriverEventTest extends PHPUnit_Framework_TestCase
+class BotManDriverEventTest extends TestCase
 {
     /** @var BotMan */
     private $botman;

--- a/tests/BotManFactoryTest.php
+++ b/tests/BotManFactoryTest.php
@@ -3,10 +3,10 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 
-class BotManFactoryTest extends PHPUnit_Framework_TestCase
+class BotManFactoryTest extends TestCase
 {
     /** @test */
     public function it_can_create_botman_instances()

--- a/tests/BotManMiddlewareTest.php
+++ b/tests/BotManMiddlewareTest.php
@@ -3,7 +3,7 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Drivers\DriverManager;
 use BotMan\BotMan\Drivers\Tests\FakeDriver;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Tests\Fixtures\TestCustomMiddleware;
 
-class BotManMiddlewareTest extends PHPUnit_Framework_TestCase
+class BotManMiddlewareTest extends TestCase
 {
     /** @var BotMan */
     private $botman;

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -5,7 +5,7 @@ namespace BotMan\BotMan\tests;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Cache\ArrayCache;
@@ -36,7 +36,7 @@ use BotMan\BotMan\Exceptions\Core\UnexpectedValueException;
 /**
  * Class BotManTest.
  */
-class BotManTest extends PHPUnit_Framework_TestCase
+class BotManTest extends TestCase
 {
     /** @var MockInterface */
     protected $commander;

--- a/tests/ButtonTest.php
+++ b/tests/ButtonTest.php
@@ -3,10 +3,10 @@
 namespace BotMan\BotMan\tests;
 
 use Illuminate\Support\Arr;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Messages\Outgoing\Actions\Button;
 
-class ButtonTest extends PHPUnit_Framework_TestCase
+class ButtonTest extends TestCase
 {
     /** @test */
     public function it_can_be_created()

--- a/tests/Cache/ArrayCacheTest.php
+++ b/tests/Cache/ArrayCacheTest.php
@@ -2,10 +2,10 @@
 
 namespace BotMan\BotMan\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Cache\ArrayCache;
 
-class ArrayCacheTest extends PHPUnit_Framework_TestCase
+class ArrayCacheTest extends TestCase
 {
     /** @test */
     public function has()

--- a/tests/Cache/CodeIgniterCacheTest.php
+++ b/tests/Cache/CodeIgniterCacheTest.php
@@ -4,10 +4,10 @@ namespace BotMan\BotMan\Tests;
 
 use CI_Cache;
 use Mockery as m;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Cache\CodeIgniterCache;
 
-class CodeIgniterCacheTest extends PHPUnit_Framework_TestCase
+class CodeIgniterCacheTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/DoctrineCacheTest.php
+++ b/tests/Cache/DoctrineCacheTest.php
@@ -3,11 +3,11 @@
 namespace BotMan\BotMan\Tests;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Cache\DoctrineCache;
 use Doctrine\Common\Cache\CacheProvider;
 
-class DoctrineCacheTest extends PHPUnit_Framework_TestCase
+class DoctrineCacheTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/Psr6CacheTest.php
+++ b/tests/Cache/Psr6CacheTest.php
@@ -3,12 +3,12 @@
 namespace BotMan\BotMan\Tests;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use BotMan\BotMan\Cache\Psr6Cache;
 use Psr\Cache\CacheItemPoolInterface;
 
-class Psr6CacheTest extends PHPUnit_Framework_TestCase
+class Psr6CacheTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -4,14 +4,14 @@ namespace BotMan\BotMan\Tests;
 
 use Redis;
 use RedisException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Cache\ArrayCache;
 use BotMan\BotMan\Cache\RedisCache;
 
 /**
  * @group integration
  */
-class RedisCacheTest extends PHPUnit_Framework_TestCase
+class RedisCacheTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Cache/SymfonyCacheTest.php
+++ b/tests/Cache/SymfonyCacheTest.php
@@ -3,13 +3,13 @@
 namespace BotMan\BotMan\Tests;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use BotMan\BotMan\Cache\SymfonyCache;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 
-class SymfonyCacheTest extends PHPUnit_Framework_TestCase
+class SymfonyCacheTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/ConversationTest.php
+++ b/tests/ConversationTest.php
@@ -6,10 +6,10 @@ use Mockery as m;
 use BotMan\BotMan\BotMan;
 use Mockery\MockInterface;
 use SuperClosure\Serializer;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Tests\Fixtures\TestConversation;
 
-class ConversationTest extends PHPUnit_Framework_TestCase
+class ConversationTest extends TestCase
 {
     /** @var MockInterface */
     protected $commander;

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -3,13 +3,13 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\Http\Curl;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Drivers\NullDriver;
 use BotMan\BotMan\Drivers\DriverManager;
 use BotMan\BotMan\Tests\Fixtures\TestDriver;
 use BotMan\BotMan\Tests\Fixtures\TestDriverWithSubDriver;
 
-class DriverManagerTest extends PHPUnit_Framework_TestCase
+class DriverManagerTest extends TestCase
 {
     protected function tearDown()
     {

--- a/tests/Drivers/FakeDriverTest.php
+++ b/tests/Drivers/FakeDriverTest.php
@@ -3,7 +3,7 @@
 namespace BotMan\BotMan\tests\Drivers;
 
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Drivers\DriverManager;
 use BotMan\BotMan\Drivers\Tests\FakeDriver;
@@ -15,7 +15,7 @@ use BotMan\BotMan\Messages\Incoming\IncomingMessage;
  * @covers \BotMan\BotMan\Drivers\FakeDriver
  * @covers \BotMan\BotMan\Drivers\Tests\ProxyDriver
  */
-class FakeDriverTest extends PHPUnit_Framework_TestCase
+class FakeDriverTest extends TestCase
 {
     /** @var BotMan */
     private $botman;

--- a/tests/Exceptions/ExceptionTest.php
+++ b/tests/Exceptions/ExceptionTest.php
@@ -5,7 +5,7 @@ namespace BotMan\BotMan\tests;
 use Exception;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Cache\ArrayCache;
@@ -14,7 +14,7 @@ use BotMan\BotMan\Tests\Fixtures\TestClass;
 use BotMan\BotMan\Exceptions\Base\BotManException;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class ExceptionTest extends PHPUnit_Framework_TestCase
+class ExceptionTest extends TestCase
 {
     /** @var ArrayCache */
     protected $cache;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,10 +2,10 @@
 
 namespace BotMan\BotMan\tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class MessageTest extends PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     /** @test */
     public function it_can_be_created()

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -2,12 +2,12 @@
 
 namespace BotMan\BotMan\tests\Messages;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Messages\Attachments\Image;
 use BotMan\BotMan\Messages\Attachments\Video;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 
-class MessageTest extends PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     /** @test */
     public function it_can_be_created()

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -5,14 +5,14 @@ namespace BotMan\BotMan\tests\Middleware;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Http\Curl;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Cache\ArrayCache;
 use BotMan\BotMan\Middleware\ApiAi;
 use Symfony\Component\HttpFoundation\Response;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class ApiAiTest extends PHPUnit_Framework_TestCase
+class ApiAiTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -5,14 +5,14 @@ namespace BotMan\BotMan\tests\Middleware;
 use Mockery as m;
 use BotMan\BotMan\BotMan;
 use BotMan\BotMan\Http\Curl;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Middleware\Wit;
 use BotMan\BotMan\Cache\ArrayCache;
 use Symfony\Component\HttpFoundation\Response;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class WitTest extends PHPUnit_Framework_TestCase
+class WitTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/QuestionTest.php
+++ b/tests/QuestionTest.php
@@ -3,11 +3,11 @@
 namespace BotMan\BotMan\tests;
 
 use Illuminate\Support\Arr;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Messages\Outgoing\Question;
 use BotMan\BotMan\Messages\Outgoing\Actions\Button;
 
-class QuestionTest extends PHPUnit_Framework_TestCase
+class QuestionTest extends TestCase
 {
     /** @test */
     public function it_can_be_created()

--- a/tests/Storages/BotManStorageTest.php
+++ b/tests/Storages/BotManStorageTest.php
@@ -3,13 +3,13 @@
 namespace BotMan\BotMan\tests\Storages;
 
 use Mockery as m;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Storages\Storage;
 use BotMan\BotMan\Drivers\Tests\FakeDriver;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class BotManStorageTest extends PHPUnit_Framework_TestCase
+class BotManStorageTest extends TestCase
 {
     protected function getBot()
     {

--- a/tests/Storages/FileStorageTest.php
+++ b/tests/Storages/FileStorageTest.php
@@ -2,10 +2,10 @@
 
 namespace BotMan\BotMan\tests\Storages;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Storages\Drivers\FileStorage;
 
-class FileStorageTest extends PHPUnit_Framework_TestCase
+class FileStorageTest extends TestCase
 {
     /** @var FileStorage */
     protected $storage;

--- a/tests/Storages/RedisStorageTest.php
+++ b/tests/Storages/RedisStorageTest.php
@@ -4,14 +4,14 @@ namespace BotMan\BotMan\Tests;
 
 use Redis;
 use RedisException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Storages\Drivers\RedisStorage;
 
 /**
  * @group integration
  */
-class RedisStorageTest extends PHPUnit_Framework_TestCase
+class RedisStorageTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Storages/StorageTest.php
+++ b/tests/Storages/StorageTest.php
@@ -2,11 +2,11 @@
 
 namespace BotMan\BotMan\tests\Storages;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Storages\Storage;
 use BotMan\BotMan\Storages\Drivers\FileStorage;
 
-class StorageTest extends PHPUnit_Framework_TestCase
+class StorageTest extends TestCase
 {
     /** @var Storage */
     protected $storage;

--- a/tests/Unit/BotManTest.php
+++ b/tests/Unit/BotManTest.php
@@ -4,7 +4,7 @@ namespace BotMan\BotMan\tests\Unit;
 
 use Mockery as m;
 use BotMan\BotMan\BotMan;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Cache\ArrayCache;
@@ -12,7 +12,7 @@ use BotMan\BotMan\Drivers\Tests\FakeDriver;
 use BotMan\BotMan\Tests\Fixtures\TestConversation;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 
-class BotManTest extends PHPUnit_Framework_TestCase
+class BotManTest extends TestCase
 {
     protected $cache;
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -3,9 +3,9 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\Users\User;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UserTest extends PHPUnit_Framework_TestCase
+class UserTest extends TestCase
 {
     private $userId = 'U023BECGF';
     private $userFirstName = 'Bobby';

--- a/tests/VerifiesServicesTest.php
+++ b/tests/VerifiesServicesTest.php
@@ -2,7 +2,7 @@
 
 namespace BotMan\BotMan\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\BotManFactory;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Drivers\DriverManager;
@@ -17,7 +17,7 @@ use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 /**
  * Class VerifiesServicesTest.
  */
-class VerifiesServicesTest extends PHPUnit_Framework_TestCase
+class VerifiesServicesTest extends TestCase
 {
     /** @test */
     public function it_can_verify_drivers()


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).