### PR TITLE
update `react/socket` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "tightenco/collect": "~5.0",
         "opis/closure": "^2.3",
         "mpociot/pipeline": "^1.0",
-        "react/socket": "0.4.*",
+        "react/socket": "~0.4",
         "spatie/macroable": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
allow 'minor' updates on this dependency. not sure if there was a reason it was initially constrained so tightly, but all test are passing with the updated version.