### PR TITLE
Allow to use Command instance instead of Command class

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -622,12 +622,17 @@ class BotMan
     }
 
     /**
-     * @param string|Closure $callback
-     * @return callable
+     * @param $callback
+     * @return array|string|Closure
+     * @throws UnexpectedValueException
      */
     protected function getCallable($callback)
     {
         if ($callback instanceof Closure) {
+            return $callback;
+        }
+
+        if (is_array($callback)) {
             return $callback;
         }
 

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -216,6 +216,23 @@ class BotManTest extends TestCase
     }
 
     /** @test */
+    public function it_can_used_instance_commands()
+    {
+        $botman = $this->getBot([
+            'sender' => 'UX12345',
+            'recipient' => 'general',
+            'message' => 'Foo',
+        ]);
+
+        $command = new TestClass($botman);
+
+        $botman->hears('Foo', [$command, 'foo']);
+        $botman->listen();
+
+        $this->assertTrue($command::$called);
+    }
+    
+    /** @test */
     public function it_does_not_hear_bot_commands()
     {
         $called = false;


### PR DESCRIPTION
In some case you need to have some commands with dependencies. Allow commands instances is the way to have complexe command. 

Eg: You want a command to interact with an external service like "G Suite". You want to create a directory in G Drive. You need to inject GDrive service to your command. It's not possible without this lines.

I hope this PR will be merged.