### PR TITLE
Change variable name ougoingMessage to outgoingMessage

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -53,7 +53,7 @@ class BotMan
     protected $message;
 
     /** @var OutgoingMessage|Question */
-    protected $ougoingMessage;
+    protected $outgoingMessage;
 
     /** @var string */
     protected $driverName;


### PR DESCRIPTION
In Botman.php, line number 56 variable name is ougoingMessage. Everywhere in the Botman outgoingMessage is used so, I thought it should also be outgoingMessage.