### PR TITLE
Update phpdoc for Command::skipsConversation()

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -114,7 +114,7 @@ class Command
     }
 
     /**
-     * With this command a current conversation should be stopped.
+     * With this command a current conversation should be skipped.
      */
     public function skipsConversation()
     {


### PR DESCRIPTION
Current docs says, that conversation should be stopped, which is misleading.
Changed to `skipped`.