### PR TITLE
Enables usage of BotMan instance in questions outside of conversation

### DIFF
--- a/src/Messages/Conversations/Conversation.php
+++ b/src/Messages/Conversations/Conversation.php
@@ -46,6 +46,14 @@ abstract class Conversation
     }
 
     /**
+     * @return BotMan
+     */
+    public function getBot()
+    {
+        return $this->bot;
+    }
+
+    /**
      * @param string|Question $question
      * @param array|Closure $next
      * @param array $additionalParameters

--- a/tests/ConversationTest.php
+++ b/tests/ConversationTest.php
@@ -89,4 +89,13 @@ class ConversationTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    public function it_can_return_bot_instance()
+    {
+        $conversation = new TestConversation();
+        $bot = m::mock(BotMan::class);
+        $conversation->setBot($bot);
+        $this->assertEquals($bot, $conversation->getBot());
+    }
 }


### PR DESCRIPTION
This should enable something like this without serialization issues:
```php
class Example {
   public function test(BotMan $bot)
   {
       $bot->ask($question, function (Answer $answer) {
          // @var $this InlineConversation
          $this->getBot()->types();
       }
   }
}

$bot->hears('test', Example::class.'@test')
```

I'm not really sure how to test it outside of just setting $bot and validatings it's not null.
close issue #672 