### PR TITLE
Define response variable for say function

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -488,6 +488,7 @@ class BotMan
 
         $previousDriver = $this->driver;
         $previousMessage = $this->message;
+        $response = '';
 
         if ($driver instanceof DriverInterface) {
             $this->setDriver($driver);


### PR DESCRIPTION
I seen that $response is defined inside the loop. I think we have to declare it outside the loop.

In other way we can also do it as checking that the response is null or not by using PHP function isset().