### PR TITLE
Fix instanciation of Messages/Outgoing/Question

### DIFF
--- a/src/Messages/Outgoing/Question.php
+++ b/src/Messages/Outgoing/Question.php
@@ -37,6 +37,7 @@ class Question implements JsonSerializable, WebAccess
     public function __construct($text)
     {
         $this->text = $text;
+        $this->actions = [];
     }
 
     /**

--- a/tests/Messages/QuestionTest.php
+++ b/tests/Messages/QuestionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BotMan\BotMan\tests\Messages;
+
+use PHPUnit\Framework\TestCase;
+use BotMan\BotMan\Messages\Outgoing\Question;
+use BotMan\BotMan\Messages\Outgoing\Actions\Button;
+
+class QuestionTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $message = Question::create('foo');
+        $this->assertSame('foo', $message->getText());
+        $this->assertSame([], $message->getActions());
+
+        $message = new Question('foo');
+        $this->assertSame('foo', $message->getText());
+        $this->assertSame([], $message->getActions());
+    }
+
+    /** @test */
+    public function it_can_add_an_action()
+    {
+        $button = Button::create('bar');
+        $message = Question::create('foo')->addAction($button);
+        $this->assertSame([$button->toArray()], $message->getActions());
+    }
+
+    /** @test */
+    public function it_can_add_a_button()
+    {
+        $button = Button::create('bar');
+        $message = Question::create('foo')->addButton($button);
+        $this->assertSame([$button->toArray()], $message->getButtons());
+    }
+
+    /** @test */
+    public function it_can_add_buttons()
+    {
+        $barButton = Button::create('bar');
+        $bazButton = Button::create('baz');
+        $message = Question::create('foo')->addButtons([$barButton, $bazButton]);
+        $this->assertSame([$barButton->toArray(), $bazButton->toArray()], $message->getButtons());
+    }
+
+    /** @test */
+    public function it_can_add_a_callback_id()
+    {
+        $message = Question::create('foo')->callbackId('callback');
+        $this->assertArraySubset(['callback_id' => 'callback'], $message->toArray());
+    }
+
+    /** @test */
+    public function it_can_add_a_fallback()
+    {
+        $message = Question::create('foo')->fallback('fallback');
+        $this->assertArraySubset(['fallback' => 'fallback'], $message->toArray());
+    }
+
+    /** @test */
+    public function it_can_be_serialized()
+    {
+        $message = Question::create('foo');
+        $this->assertSame('{"text":"foo","fallback":null,"callback_id":null,"actions":[]}', json_encode($message));
+    }
+
+    /** @test */
+    public function it_can_return_a_web_accessible_array()
+    {
+        $message = Question::create('foo');
+        $this->assertSame([
+            'type' => 'text',
+            'text' => 'foo',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [],
+        ], $message->toWebDriver());
+    }
+
+    /** @test */
+    public function it_can_return_a_web_accessible_array_with_actions()
+    {
+        $button = Button::create('bar');
+        $message = Question::create('foo')->addAction($button);
+        $this->assertSame([
+            'type' => 'actions',
+            'text' => 'foo',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [$button->toArray()],
+        ], $message->toWebDriver());
+    }
+}


### PR DESCRIPTION
There was an issue in (only) PHP 7.2 when calling `toWebDriver` in `Messages/Outgoing/Question`:
```
An error occurred: Warning: count(): Parameter must be an array or an object that implements Countable in /home/travis/build/Quotatis/dora/vendor/botman/botman/src/Messages/Outgoing/Question.php line 153
```
This was not detected because there was no test for this class.
This PR adds some unit tests for it and fix the issue by setting an empty array for `$actions` in the constructor.