### PR TITLE
Fix Wit not matching any pattern

### DIFF
--- a/src/Middleware/Wit.php
+++ b/src/Middleware/Wit.php
@@ -99,12 +99,13 @@ class Wit implements MiddlewareInterface
     public function matching(IncomingMessage $message, $pattern, $regexMatched)
     {
         $entities = Collection::make($message->getExtras())->get('entities', []);
-
+        $pattern = '/^'.$pattern.'$/i';
+        
         if (! empty($entities)) {
             foreach ($entities as $name => $entity) {
                 if ($name === 'intent') {
                     foreach ($entity as $item) {
-                        if ($item['value'] === $pattern && $item['confidence'] >= $this->minimumConfidence) {
+                        if ((bool) preg_match($pattern, $item['value']) && $item['confidence'] >= $this->minimumConfidence) {
                             return true;
                         }
                     }

--- a/src/Middleware/Wit.php
+++ b/src/Middleware/Wit.php
@@ -100,7 +100,7 @@ class Wit implements MiddlewareInterface
     {
         $entities = Collection::make($message->getExtras())->get('entities', []);
         $pattern = '/^'.$pattern.'$/i';
-        
+
         if (! empty($entities)) {
             foreach ($entities as $name => $entity) {
                 if ($name === 'intent') {

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -90,7 +90,7 @@ class WitTest extends TestCase
 
         $middleware = new Wit('token', 0.5, $http);
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertTrue($middleware->matching($message, 'emotion', false));
+        $this->assertTrue($middleware->matching($message, '.*(emotion)*.', false));
     }
 
     /** @test */

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -90,7 +90,7 @@ class WitTest extends TestCase
 
         $middleware = new Wit('token', 0.5, $http);
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertTrue($middleware->matching($message, '.*(emotion)*.', false));
+        $this->assertTrue($middleware->matching($message, '.*(emotion).*', false));
     }
 
     /** @test */

--- a/tests/Middleware/WitTest.php
+++ b/tests/Middleware/WitTest.php
@@ -134,7 +134,7 @@ class WitTest extends TestCase
 
         $middleware = new Wit('token', 0.5, $http);
         $middleware->received($message, $callback, m::mock(BotMan::class));
-        $this->assertFalse($middleware->matching($message, 'emotion', false));
+        $this->assertFalse($middleware->matching($message, '.*(emotion)*.', false));
     }
 
     /** @test */


### PR DESCRIPTION
The problem with trying to match the exact word to the `intent` value like this

```
($item['value'] === $pattern && $item['confidence'] >= $this->minimumConfidence)
```
Is that we cant use any pattern, and we should use the exact words, otherwise it will not match anything and we will have to only relay on the global received middleware so this code:

```
$wit = Wit::create(env('WIT_SECRET'));

$botman->middleware->received($wit);

$botman->group([ 'middleware' => $wit ], function($bot) {
	$bot->hears('.*(hello).*', function($bot){
		  return $bot->reply("I can hear you");
	});
});

$botman->hears('.*(hello).*', function($bot){
	return $bot->reply("I can hear you");
})->middleware($wit);

```
Wont work. and to make it work we should replace `.*(hello).*` with the exact word `hello`, as the tests indicated:

```
$this->assertFalse($middleware->matching($message, 'emotion', false));
```
So replacing the exact match with preg_match will insure that the use of either `hello` or `.*(hello).*` will work.

Thanks