### PR TITLE
Replace rtrim with preg_replace

### DIFF
--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -67,7 +67,7 @@ class DriverManager
         * DriverInterface object.
         */
         if (class_exists($name) && is_subclass_of($name, DriverInterface::class)) {
-            $name = rtrim(basename(str_replace('\\', '/', $name)), 'Driver');
+            $name = preg_replace("#(Driver$)#", '', basename(str_replace('\\', '/', $name)));
         }
         /*
          * Use the driver name constant if we try to load a driver by it's

--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -67,7 +67,7 @@ class DriverManager
         * DriverInterface object.
         */
         if (class_exists($name) && is_subclass_of($name, DriverInterface::class)) {
-            $name = preg_replace("#(Driver$)#", '', basename(str_replace('\\', '/', $name)));
+            $name = preg_replace('#(Driver$)#', '', basename(str_replace('\\', '/', $name)));
         }
         /*
          * Use the driver name constant if we try to load a driver by it's

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -3,6 +3,7 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\Http\Curl;
+use BotMan\BotMan\Tests\Fixtures\AnotherDriver;
 use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Drivers\NullDriver;
 use BotMan\BotMan\Drivers\DriverManager;
@@ -15,6 +16,7 @@ class DriverManagerTest extends TestCase
     {
         DriverManager::unloadDriver(TestDriver::class);
         DriverManager::unloadDriver(TestDriverWithSubDriver::class);
+        DriverManager::unloadDriver(AnotherDriver::class);
         \Mockery::close();
     }
 
@@ -79,6 +81,11 @@ class DriverManagerTest extends TestCase
         DriverManager::loadDriver(TestDriver::class);
         $this->assertInstanceOf(TestDriver::class, DriverManager::loadFromName('Test', []));
         $this->assertInstanceOf(TestDriver::class, DriverManager::loadFromName(TestDriver::class, []));
+
+        // This driver has the characters 'e' and 'r' from 'Driver' charset in the old rtrim way of fetching the driver's name
+        DriverManager::loadDriver(AnotherDriver::class);
+        $this->assertInstanceOf(AnotherDriver::class, DriverManager::loadFromName('Another', []));
+        $this->assertInstanceOf(AnotherDriver::class, DriverManager::loadFromName(AnotherDriver::class, []));
     }
 
     /** @test */

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -3,11 +3,11 @@
 namespace BotMan\BotMan\tests;
 
 use BotMan\BotMan\Http\Curl;
-use BotMan\BotMan\Tests\Fixtures\AnotherDriver;
 use PHPUnit\Framework\TestCase;
 use BotMan\BotMan\Drivers\NullDriver;
 use BotMan\BotMan\Drivers\DriverManager;
 use BotMan\BotMan\Tests\Fixtures\TestDriver;
+use BotMan\BotMan\Tests\Fixtures\AnotherDriver;
 use BotMan\BotMan\Tests\Fixtures\TestDriverWithSubDriver;
 
 class DriverManagerTest extends TestCase

--- a/tests/Fixtures/AnotherDriver.php
+++ b/tests/Fixtures/AnotherDriver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BotMan\BotMan\Tests\Fixtures;
+
+class AnotherDriver extends TestDriver
+{
+    /**
+     * Return the driver name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Another';
+    }
+}


### PR DESCRIPTION
Hello,

So I was making a custom driver to send private HipChat notifications so I named my driver `HipChatPrivateDriver` but I noticed the name of the driver was `HipChatPrivat` and not the expected `HipChatPrivate` (missing the last **e**).

I did some digging and found an [rtrim](http://php.net/manual/en/function.rtrim.php) for getting the name of the driver (from the given name) but an rtrim looks for matching characters and not the entire string. (because `e` was in the list of characters `Driver` it returned the wrong name)

I've fixed this by replacing the function with a preg_replace where we check for `Driver` as a whole at the end of the string. (So you could have a driver called `AwesomeDriverDriver` which now turns into `AwesomeDriver` instead of `Awesom`)

I've created a new test driver called `AnotherDriver` which extends `TestDriver`. I hope this is Ok with you. If not I can update `AnotherDriver` to be its own entity.