### PR TITLE
Fixed callFallbackMessage if no messages

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -475,7 +475,13 @@ class BotMan
      */
     protected function callFallbackMessage()
     {
-        $this->message = $this->getMessages()[0];
+        $messages = $this->getMessages();
+        
+        if (!isset($messages[0])) {
+            return;
+        }
+        
+        $this->message = $messages[0];
 
         $this->fallbackMessage = $this->getCallable($this->fallbackMessage);
 


### PR DESCRIPTION
I've added a handling if the getMessages() method didn't return any message in the callFallbackMessage() method.
I'm not 100% sure if just a return is good enough but it fixed it for me.

Fix for #752