### PR TITLE
Add support for float seconds in typesAndWaits() method

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -563,10 +563,10 @@ class BotMan
     }
 
     /**
-     * @param int $seconds Number of seconds to wait
+     * @param float $seconds Number of seconds to wait
      * @return $this
      */
-    public function typesAndWaits($seconds)
+    public function typesAndWaits(float $seconds)
     {
         $this->getDriver()->typesAndWaits($this->message, $seconds);
 

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -81,13 +81,13 @@ abstract class HttpDriver implements DriverInterface
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
         $this->types($matchingMessage);
-        sleep($seconds);
+        usleep($seconds * 1000000);
     }
 
     /**

--- a/src/Drivers/Tests/FakeDriver.php
+++ b/src/Drivers/Tests/FakeDriver.php
@@ -173,10 +173,10 @@ class FakeDriver implements DriverInterface, VerifiesService
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
         $this->types($matchingMessage);
     }

--- a/src/Drivers/Tests/ProxyDriver.php
+++ b/src/Drivers/Tests/ProxyDriver.php
@@ -108,10 +108,10 @@ final class ProxyDriver implements DriverInterface
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
         return self::instance()->typesAndWaits($matchingMessage, $seconds);
     }

--- a/src/Interfaces/DriverInterface.php
+++ b/src/Interfaces/DriverInterface.php
@@ -77,10 +77,10 @@ interface DriverInterface
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds);
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds);
 
     /**
      * Tells if the stored conversation callbacks are serialized.

--- a/tests/Fixtures/TestDriver.php
+++ b/tests/Fixtures/TestDriver.php
@@ -141,10 +141,10 @@ class TestDriver implements DriverInterface, VerifiesService
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
         //
     }

--- a/tests/Fixtures/TestDriverWithSubDriver.php
+++ b/tests/Fixtures/TestDriverWithSubDriver.php
@@ -144,10 +144,10 @@ class TestDriverWithSubDriver implements DriverInterface
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
     }
 }

--- a/tests/VerifiesServicesTest.php
+++ b/tests/VerifiesServicesTest.php
@@ -140,10 +140,10 @@ class DummyDriver extends HttpDriver implements VerifiesService
     /**
      * Send a typing indicator and wait for the given amount of seconds.
      * @param IncomingMessage $matchingMessage
-     * @param int $seconds
+     * @param float $seconds
      * @return mixed
      */
-    public function typesAndWaits(IncomingMessage $matchingMessage, int $seconds)
+    public function typesAndWaits(IncomingMessage $matchingMessage, float $seconds)
     {
     }
 }


### PR DESCRIPTION
The proposed breaking changes (changes to DriverInterface) allow the use of float seconds in the typesAndWaits() method.