### PR TITLE
Accept trailing whitespace in case of using the Slack's slash commands

### DIFF
--- a/src/Messages/Matcher.php
+++ b/src/Messages/Matcher.php
@@ -52,7 +52,7 @@ class Matcher
         }
 
         $pattern = str_replace('/', '\/', $pattern);
-        $text = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).'$/miu';
+        $text = '/^'.preg_replace(self::PARAM_NAME_REGEX, '(?<$1>.*)', $pattern).' ?$/miu';
 
         $regexMatched = (bool) preg_match($text, $message->getText(), $this->matches) || (bool) preg_match($text, $answerText, $this->matches);
 

--- a/tests/Messages/MatcherTest.php
+++ b/tests/Messages/MatcherTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace BotMan\BotMan\tests\Messages;
+
+use BotMan\BotMan\Messages\Incoming\Answer;
+use BotMan\BotMan\Messages\Incoming\IncomingMessage;
+use BotMan\BotMan\Messages\Matcher;
+use PHPUnit\Framework\TestCase;
+
+class MatcherTest extends TestCase
+{
+
+    /**
+     * Dataprovider:
+     *  [[$input, $pattern, $expected]]
+     *
+     * @return array
+     */
+    public function incoming_message_provider()
+    {
+        $messages = [
+            ['foo', 'foo', true,],
+            ['foo ', 'foo', true,],
+            ['foo ', 'foo ', true,],
+
+            ['call me foo', 'call me {name}', true,],
+            ['call me foo ', 'call me {name}', true,],
+            ['call me foo ', 'call me {name} ', true,],
+
+            ['call me foo baz', 'call me {name} {surname}', true,],
+            ['call me foo baz ', 'call me {name} {surname}', true,],
+            ['call me foo baz ', 'call me {name} {surname} ', true,],
+
+            ['/foo', '/foo', true,],
+            ['/foo ', '/foo', true,],
+            ['/foo ', '/foo ', true,],
+
+            ['/call me foo', '/call me {name}', true,],
+            ['/call me foo ', '/call me {name}', true,],
+            ['/call me foo ', '/call me {name} ', true,],
+
+            ['/call me foo baz', '/call me {name} {surname}', true,],
+            ['/call me foo baz ', '/call me {name} {surname}', true,],
+            ['/call me foo baz ', '/call me {name} {surname} ', true,],
+
+            ['!foo', '!foo', true,],
+            ['!foo ', '!foo', true,],
+            ['!foo ', '!foo ', true,],
+
+            ['!call me foo', '!call me {name}', true,],
+            ['!call me foo ', '!call me {name}', true,],
+            ['!call me foo ', '!call me {name} ', true,],
+
+            ['!call me foo baz', '!call me {name} {surname}', true,],
+            ['!call me foo baz ', '!call me {name} {surname}', true,],
+            ['!call me foo baz ', '!call me {name} {surname} ', true,],
+
+            ['@foo', '@foo', true,],
+            ['@foo ', '@foo', true,],
+            ['@foo ', '@foo ', true,],
+
+            ['@call me foo', '@call me {name}', true,],
+            ['@call me foo ', '@call me {name}', true,],
+            ['@call me foo ', '@call me {name} ', true,],
+
+            ['@call me foo baz', '@call me {name} {surname}', true,],
+            ['@call me foo baz ', '@call me {name} {surname}', true,],
+            ['@call me foo baz ', '@call me {name} {surname} ', true,],
+
+
+            ['!@#2f00', '!@#2f00', true,],
+            ['!@#2f00 ', '!@#2f00', true,],
+            ['!@#2f00 ', '!@#2f00 ', true,],
+
+            ['!@#2c@ll m3 f00', '!@#2c@ll m3 {nam3}', true,],
+            ['!@#2c@ll m3 f00 ', '!@#2c@ll m3 {nam3}', true,],
+            ['!@#2c@ll m3 f00 ', '!@#2c@ll m3 {nam3} ', true,],
+
+            ['!@#2c@ll m3 f00 baz', '!@#2c@ll m3 {nam3} {surnam3}', true,],
+            ['!@#2c@ll m3 f00 baz ', '!@#2c@ll m3 {nam3} {surnam3}', true,],
+            ['!@#2c@ll m3 f00 baz ', '!@#2c@ll m3 {nam3} {surnam3} ', true,],
+
+            ['foo', 'baz', false,],
+            ['foo ', 'baz', false,],
+            ['foo ', 'baz ', false,],
+        ];
+
+        return $messages;
+    }
+
+    /**
+     * @dataProvider incoming_message_provider
+     * @dataProvider
+     *
+     * @param string $message
+     * @param string $pattern
+     * @param bool   $expected
+     */
+    public function test_is_pattern_valid(string $message, string $pattern, bool $expected)
+    {
+        $matcher = new Matcher();
+        $incomingMessage = new IncomingMessage($message, 'bar', 'baz');
+        $answer = new Answer();
+
+        $this->assertSame($expected, $matcher->isPatternValid($incomingMessage, $answer, $pattern),
+            sprintf('Message `%s` does not match pattern `%s`', $message, $pattern)
+        );
+    }
+}

--- a/tests/Messages/MatcherTest.php
+++ b/tests/Messages/MatcherTest.php
@@ -23,6 +23,10 @@ class MatcherTest extends TestCase
             ['foo ', 'foo', true,],
             ['foo ', 'foo ', true,],
 
+            ['foo', '{command}', true,],
+            ['foo ', '{command}', true,],
+            ['foo ', '{command} ', true,],
+
             ['call me foo', 'call me {name}', true,],
             ['call me foo ', 'call me {name}', true,],
             ['call me foo ', 'call me {name} ', true,],
@@ -34,6 +38,10 @@ class MatcherTest extends TestCase
             ['/foo', '/foo', true,],
             ['/foo ', '/foo', true,],
             ['/foo ', '/foo ', true,],
+
+            ['/foo', '/{command}', true,],
+            ['/foo ', '/{command}', true,],
+            ['/foo ', '/{command} ', true,],
 
             ['/call me foo', '/call me {name}', true,],
             ['/call me foo ', '/call me {name}', true,],
@@ -47,6 +55,10 @@ class MatcherTest extends TestCase
             ['!foo ', '!foo', true,],
             ['!foo ', '!foo ', true,],
 
+            ['!foo', '!{command}', true,],
+            ['!foo ', '!{command}', true,],
+            ['!foo ', '!{command} ', true,],
+
             ['!call me foo', '!call me {name}', true,],
             ['!call me foo ', '!call me {name}', true,],
             ['!call me foo ', '!call me {name} ', true,],
@@ -59,6 +71,10 @@ class MatcherTest extends TestCase
             ['@foo ', '@foo', true,],
             ['@foo ', '@foo ', true,],
 
+            ['@foo', '@{command}', true,],
+            ['@foo ', '@{command}', true,],
+            ['@foo ', '@{command} ', true,],
+
             ['@call me foo', '@call me {name}', true,],
             ['@call me foo ', '@call me {name}', true,],
             ['@call me foo ', '@call me {name} ', true,],
@@ -67,6 +83,21 @@ class MatcherTest extends TestCase
             ['@call me foo baz ', '@call me {name} {surname}', true,],
             ['@call me foo baz ', '@call me {name} {surname} ', true,],
 
+            ['#foo', '#foo', true,],
+            ['#foo ', '#foo', true,],
+            ['#foo ', '#foo ', true,],
+
+            ['#foo', '#{command}', true,],
+            ['#foo ', '#{command}', true,],
+            ['#foo ', '#{command} ', true,],
+
+            ['#call me foo', '#call me {name}', true,],
+            ['#call me foo ', '#call me {name}', true,],
+            ['#call me foo ', '#call me {name} ', true,],
+
+            ['#call me foo baz', '#call me {name} {surname}', true,],
+            ['#call me foo baz ', '#call me {name} {surname}', true,],
+            ['#call me foo baz ', '#call me {name} {surname} ', true,],
 
             ['!@#2f00', '!@#2f00', true,],
             ['!@#2f00 ', '!@#2f00', true,],
@@ -79,6 +110,10 @@ class MatcherTest extends TestCase
             ['!@#2c@ll m3 f00 baz', '!@#2c@ll m3 {nam3} {surnam3}', true,],
             ['!@#2c@ll m3 f00 baz ', '!@#2c@ll m3 {nam3} {surnam3}', true,],
             ['!@#2c@ll m3 f00 baz ', '!@#2c@ll m3 {nam3} {surnam3} ', true,],
+
+            [' foo', 'foo', false,],
+            [' foo', 'foo ', false,],
+            [' foo ', 'foo ', false,],
 
             ['foo', 'baz', false,],
             ['foo ', 'baz', false,],
@@ -103,7 +138,10 @@ class MatcherTest extends TestCase
         $answer = new Answer();
 
         $this->assertSame($expected, $matcher->isPatternValid($incomingMessage, $answer, $pattern),
-            sprintf('Message `%s` does not match pattern `%s`', $message, $pattern)
+            sprintf('Message `%s` and pattern `%s` should assert `%s`',
+                $message,
+                $pattern,
+                $expected ? 'true' : 'false')
         );
     }
 }


### PR DESCRIPTION
Slack slash command, for example `/cfp`, will be send with a trailing slash. I expanded the regex to cover a optional whitespace.

Slack will send slash commands with a trailing slash (`/cfp` will be received as `/cfp `) which causes the regex to not validate correctly. 