### PR TITLE
Allow only one reply for matching commands

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -467,7 +467,9 @@ class BotMan
 
             $parameters = $this->conversationManager->addDataParameters($this->message, $parameters);
 
-            \call_user_func_array($callback, $parameters);
+            if (call_user_func_array($callback, $parameters)) {
+                return;
+            }
         }
 
         if (empty($matchingMessages) && empty($this->getBotMessages()) && ! \is_null($this->fallbackMessage)) {

--- a/tests/BotManTest.php
+++ b/tests/BotManTest.php
@@ -204,7 +204,8 @@ class BotManTest extends TestCase
     /** @test */
     public function it_hears_matching_commands()
     {
-        $called = false;
+        $called_once = false;
+        $called_twice = false;
 
         $botman = $this->getBot([
             'sender' => 'UX12345',
@@ -212,11 +213,44 @@ class BotManTest extends TestCase
             'message' => 'Foo',
         ]);
 
-        $botman->hears('Foo', function ($bot) use (&$called) {
-            $called = true;
+        $botman->hears('Foo', function ($bot) use (&$called_once) {
+            $called_once = true;
         });
+
+        $botman->hears('Foo(.*)', function ($bot) use (&$called_twice) {
+            $called_twice = true;
+        });
+
         $botman->listen();
-        $this->assertTrue($called);
+        $this->assertTrue($called_once);
+        $this->assertTrue($called_twice);
+    }
+
+    /** @test */
+    public function it_hears_only_first_matching_command_that_returns()
+    {
+        $called_once = false;
+        $called_twice = false;
+
+        $botman = $this->getBot([
+            'sender' => 'UX12345',
+            'recipient' => 'general',
+            'message' => 'Foo',
+        ]);
+
+        $botman->hears('Foo', function ($bot) use (&$called_once) {
+            $called_once = true;
+
+            return true;
+        });
+
+        $botman->hears('Foo(.*)', function ($bot) use (&$called_twice) {
+            $called_twice = true;
+        });
+
+        $botman->listen();
+        $this->assertTrue($called_once);
+        $this->assertFalse($called_twice);
     }
 
     /** @test */


### PR DESCRIPTION
As mention in #333 some times you need to reply with only one message if you have multiple commands that may get triggered.

For example

![image](https://user-images.githubusercontent.com/1344188/40455492-0d9d8c68-5ee5-11e8-9725-1affcd0ae5a0.png)

```php
// DialogFlow custom comand fires most of the time.
$botman->hears('input.joke', function ($bot) {
    $extras = $bot->getMessage()->getExtras();
    $bot->reply('1 : ' . $extras['apiReply']);
    return true; // If we get to here terminate...
})->middleware($dialogflow);

// Hardcoded command as a fallback in case DialogFlow cannot catch the comand
$botman->hears('.*Joke.*', function ($bot) {
    $joke = json_decode(file_get_contents('http://api.icndb.com/jokes/random'));
    $bot->reply('2 : ' . $joke->value->joke);
});

```
By warping the callback function inside  `botman\src\Botman.php::callMatchingMessages` with simple if statement we can allow return > null to terminate the search.
 
```php
    /**
     * Call matching message callbacks.
     */
    protected function callMatchingMessages()
    {
            ...

            if (call_user_func_array($callback, $parameters)) {
                return;
            }
    }
    ...
```
