### PR TITLE
Correct doc comment for say method

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -497,7 +497,7 @@ class BotMan
     /**
      * @param string|Question $message
      * @param string|array $recipients
-     * @param DriverInterface|null $driver
+     * @param DriverInterface|string|null $driver
      * @param array $additionalParameters
      * @return Response
      * @throws BotManException


### PR DESCRIPTION
According to https://github.com/botman/botman/blob/2.0/src/BotMan.php#L535-L537 the method `say` does accept a string for the driver which is then loaded by name. 