### PR TITLE
Update LaravelCache.php

### DIFF
--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -57,6 +57,6 @@ class LaravelCache implements CacheInterface
      */
     public function put($key, $value, $minutes)
     {
-        Cache::put($key, $value, $minutes);
+        Cache::put($key, $value, $minutes * 60);
     }
 }


### PR DESCRIPTION
A recent change in Laravel 5.8 made it so the cache TTL is in seconds, instead of minutes.
See https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds for more details.

This would make it compatible with the minutes defined in config files.