### PR TITLE
Update LaravelCache.php

### DIFF
--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -57,7 +57,7 @@ class LaravelCache implements CacheInterface
      */
     public function put($key, $value, $minutes)
     {
-        if (!$minutes instanceof \DateTime) {
+        if (! $minutes instanceof \DateTime) {
             $minutes = $minutes * 60;
         }
         Cache::put($key, $value, $minutes);

--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -57,6 +57,9 @@ class LaravelCache implements CacheInterface
      */
     public function put($key, $value, $minutes)
     {
+        if (!$minutes instanceof \DateTime) {
+            $minutes = $minutes * 60;
+        }
         Cache::put($key, $value, $minutes);
     }
 }


### PR DESCRIPTION
A recent change in Laravel 5.8 changed the TTL from minutes to seconds.
See https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds for more details.

This would keep it compatible with other caching drivers also using minutes.