### PR TITLE
Make the PHPDoc of the say method complete

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -529,7 +529,7 @@ class BotMan
     /**
      * @param string|Question $message
      * @param string|array $recipients
-     * @param DriverInterface|null $driver
+     * @param DriverInterface|string|null $driver
      * @param array $additionalParameters
      * @return Response
      * @throws BotManException


### PR DESCRIPTION
You can also pass a string as driver to the say method, which assumes it's a resolvable class name.