### PR TITLE
Indicate possible null values in PHPDoc @return

### DIFF
--- a/src/Interfaces/UserInterface.php
+++ b/src/Interfaces/UserInterface.php
@@ -10,17 +10,17 @@ interface UserInterface
     public function getId();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getUsername();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstName();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastName();
 


### PR DESCRIPTION
To prevent error messages from PHPStan like:

```
Method                                                                  
         MyProject\Domain\Bot::getChatUsername()   
         never returns null so it can be removed from the return typehint.
```

when using code like this:
```php
class Bot{

    /** @var BotManApiClient */
    private $botMan;

    public function getChatUsername() : ?string
    {
        return $this->botMan->getUser()->getUserName();
    }
}
```