### PR TITLE
Added OutgoingMessage type to BotMan::reply() $message parameter

### DIFF
--- a/src/BotMan.php
+++ b/src/BotMan.php
@@ -627,7 +627,7 @@ class BotMan
     }
 
     /**
-     * @param string|Question $message
+     * @param string|OutgoingMessage|Question $message
      * @param array $additionalParameters
      * @return mixed
      */


### PR DESCRIPTION
Added `OutgoingMessage` as an accepted type for the `$message` parameter of `BotMan::reply()`.

This fixes static analysis errors like the following from psalm.

```
ERROR: InvalidArgument - app/Path/To/SomeFile.php:13:37 - Argument 1 of BotMan\BotMan\BotMan::reply expects BotMan\BotMan\Messages\Outgoing\Question|string, BotMan\BotMan\Messages\Outgoing\OutgoingMessage provided
        $botman->reply(OutgoingMessage::create(...)->withAttachment(...));
```