### PR TITLE
Add TranslatableInterface to allow middleware to translate text fields

### DIFF
--- a/src/Interfaces/TranslatableInterface.php
+++ b/src/Interfaces/TranslatableInterface.php
@@ -7,5 +7,6 @@ interface TranslatableInterface
     /**
      * @param callable $callable
      */
-    public function translate(callable $callable): void;
+    public function translate(callable $callable);
+
 }

--- a/src/Interfaces/TranslatableInterface.php
+++ b/src/Interfaces/TranslatableInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BotMan\BotMan\Interfaces;
+
+interface TranslatableInterface
+{
+    /**
+     * @param callable $callable
+     */
+    public function translate(callable $callable): void;
+}

--- a/src/Messages/Attachments/Image.php
+++ b/src/Messages/Attachments/Image.php
@@ -17,6 +17,9 @@ class Image extends Attachment implements TranslatableInterface
     /** @var string */
     protected $title;
 
+    /** @var bool */
+    protected $isTranslated;
+
     /**
      * Video constructor.
      * @param string $url
@@ -82,8 +85,12 @@ class Image extends Attachment implements TranslatableInterface
     /**
      * @param callable $callable
      */
-    public function translate(callable $callable): void
+    public function translate(callable $callable)
     {
+        if ($this->isTranslated) {
+            return;
+        }
         $this->title = $callable($this->title);
+        $this->isTranslated = true;
     }
 }

--- a/src/Messages/Attachments/Image.php
+++ b/src/Messages/Attachments/Image.php
@@ -2,7 +2,9 @@
 
 namespace BotMan\BotMan\Messages\Attachments;
 
-class Image extends Attachment
+use BotMan\BotMan\Interfaces\TranslatableInterface;
+
+class Image extends Attachment implements TranslatableInterface
 {
     /**
      * Pattern that messages use to identify image uploads.
@@ -75,5 +77,13 @@ class Image extends Attachment
             'url' => $this->url,
             'title' => $this->title,
         ];
+    }
+
+    /**
+     * @param callable $callable
+     */
+    public function translate(callable $callable): void
+    {
+        $this->title = $callable($this->title);
     }
 }

--- a/src/Messages/Outgoing/Actions/Button.php
+++ b/src/Messages/Outgoing/Actions/Button.php
@@ -23,6 +23,9 @@ class Button implements JsonSerializable, QuestionActionInterface, TranslatableI
     /** @var string */
     protected $imageUrl;
 
+    /** @var bool */
+    protected $isTranslated;
+
     /**
      * @param string $text
      *
@@ -119,11 +122,15 @@ class Button implements JsonSerializable, QuestionActionInterface, TranslatableI
     /**
      * @param callable $callable
      */
-    public function translate(callable $callable): void
+    public function translate(callable $callable)
     {
+        if ($this->isTranslated) {
+            return;
+        }
         $this->text = $callable($this->text);
         if (isset($this->name)) {
             $this->name = $callable($this->name);
         }
+        $this->isTranslated = true;
     }
 }

--- a/src/Messages/Outgoing/Actions/Button.php
+++ b/src/Messages/Outgoing/Actions/Button.php
@@ -3,9 +3,10 @@
 namespace BotMan\BotMan\Messages\Outgoing\Actions;
 
 use BotMan\BotMan\Interfaces\QuestionActionInterface;
+use BotMan\BotMan\Interfaces\TranslatableInterface;
 use JsonSerializable;
 
-class Button implements JsonSerializable, QuestionActionInterface
+class Button implements JsonSerializable, QuestionActionInterface, TranslatableInterface
 {
     /** @var string */
     protected $text;
@@ -113,5 +114,16 @@ class Button implements JsonSerializable, QuestionActionInterface
     public function jsonSerialize()
     {
         return $this->toArray();
+    }
+
+    /**
+     * @param callable $callable
+     */
+    public function translate(callable $callable): void
+    {
+        $this->text = $callable($this->text);
+        if (isset($this->name)) {
+            $this->name = $callable($this->name);
+        }
     }
 }

--- a/src/Messages/Outgoing/OutgoingMessage.php
+++ b/src/Messages/Outgoing/OutgoingMessage.php
@@ -13,6 +13,9 @@ class OutgoingMessage implements TranslatableInterface
     /** @var \BotMan\BotMan\Messages\Attachments\Attachment */
     protected $attachment;
 
+    /** @var bool */
+    protected $isTranslated;
+
     /**
      * IncomingMessage constructor.
      * @param string $message
@@ -75,11 +78,16 @@ class OutgoingMessage implements TranslatableInterface
     /**
      * @param callable $callable
      */
-    public function translate(callable $callable): void
+    public function translate(callable $callable)
     {
-        $this->message = $callable($this->message);
         if ($this->attachment instanceof TranslatableInterface) {
             $this->attachment->translate($callable);
         }
+        if ($this->isTranslated) {
+            return;
+        }
+
+        $this->message = $callable($this->message);
+        $this->isTranslated = true;
     }
 }

--- a/src/Messages/Outgoing/OutgoingMessage.php
+++ b/src/Messages/Outgoing/OutgoingMessage.php
@@ -2,9 +2,10 @@
 
 namespace BotMan\BotMan\Messages\Outgoing;
 
+use BotMan\BotMan\Interfaces\TranslatableInterface;
 use BotMan\BotMan\Messages\Attachments\Attachment;
 
-class OutgoingMessage
+class OutgoingMessage implements TranslatableInterface
 {
     /** @var string */
     protected $message;
@@ -69,5 +70,16 @@ class OutgoingMessage
     public function getText()
     {
         return $this->message;
+    }
+
+    /**
+     * @param callable $callable
+     */
+    public function translate(callable $callable): void
+    {
+        $this->message = $callable($this->message);
+        if ($this->attachment instanceof TranslatableInterface) {
+            $this->attachment->translate($callable);
+        }
     }
 }

--- a/src/Messages/Outgoing/Question.php
+++ b/src/Messages/Outgoing/Question.php
@@ -25,6 +25,9 @@ class Question implements JsonSerializable, WebAccess, TranslatableInterface
     /** @var string */
     protected $fallback;
 
+    /** @var bool */
+    private $isTranslated;
+
     /**
      * @param string $text
      *
@@ -167,9 +170,8 @@ class Question implements JsonSerializable, WebAccess, TranslatableInterface
         ];
     }
 
-    public function translate(callable $callable): void
+    public function translate(callable $callable)
     {
-        $this->text = $callable($this->text);
         $translatedActions = [];
         foreach ($this->actionInstances as $actionInstance) {
             if ($actionInstance instanceof TranslatableInterface) {
@@ -177,6 +179,11 @@ class Question implements JsonSerializable, WebAccess, TranslatableInterface
             }
             $translatedActions[] = $actionInstance->toArray();
         }
+        if ($this->isTranslated) {
+            return;
+        }
+        $this->text = $callable($this->text);
         $this->actions = $translatedActions;
+        $this->isTranslated = true;
     }
 }

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -73,4 +73,34 @@ class MessageTest extends TestCase
 
         $this->assertSame('BAR', $message->getAttachment()->getTitle());
     }
+
+    /** @test */
+    public function it_can_be_translated_once_only()
+    {
+        $translationCallable = function ($text) {
+            return strrev($text);
+        };
+        $message = OutgoingMessage::create()->text('foo');
+        $message->translate($translationCallable);
+        $this->assertSame('oof', $message->getText());
+
+        $message->translate($translationCallable);
+        $this->assertSame('oof', $message->getText());
+
+    }
+
+    /** @test */
+    public function it_can_translate_attachement_once_only()
+    {
+        $translationCallable = function ($text) {
+            return strrev($text);
+        };
+        $message = OutgoingMessage::create()->withAttachment(Image::url('foo')->title('bar'));
+        $message->translate($translationCallable);
+        $this->assertSame('rab', $message->getAttachment()->getTitle());
+
+        $message->translate($translationCallable);
+        $this->assertSame('rab', $message->getAttachment()->getTitle());
+
+    }
 }

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -50,4 +50,27 @@ class MessageTest extends TestCase
         $message = OutgoingMessage::create()->withAttachment(Video::url('foo'));
         $this->assertSame('foo', $message->getAttachment()->getUrl());
     }
+
+    /** @test */
+    public function it_can_be_translated()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $message = OutgoingMessage::create()->text('foo');
+        $message->translate($translationCallable);
+        $this->assertSame('FOO', $message->getText());
+    }
+
+    /** @test */
+    public function it_can_translate_attachement()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $message = OutgoingMessage::create()->withAttachment(Image::url('foo')->title('bar'));
+        $message->translate($translationCallable);
+
+        $this->assertSame('BAR', $message->getAttachment()->getTitle());
+    }
 }

--- a/tests/Messages/QuestionTest.php
+++ b/tests/Messages/QuestionTest.php
@@ -92,4 +92,107 @@ class QuestionTest extends TestCase
             'actions' => [$button->toArray()],
         ], $message->toWebDriver());
     }
+
+    /** @test */
+    public function it_can_be_translated()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $message = Question::create("foo");
+        $message->translate($translationCallable);
+        $this->assertSame([
+            'type' => 'text',
+            'text' => 'FOO',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [],
+        ], $message->toWebDriver());
+    }
+
+    /** @test */
+    public function it_can_translate_an_action()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $button = Button::create('qux');
+        $message = Question::create("foo")->addAction($button);
+        $message->translate($translationCallable);
+        $this->assertSame([
+            'type' => 'actions',
+            'text' => 'FOO',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [[
+                'name' => 'QUX',
+                'text' => 'QUX',
+                'image_url' => null,
+                'type' => 'button',
+                'value' => null,
+                'additional' => [],
+            ]],
+        ], $message->toWebDriver());
+    }
+
+    /** @test */
+    public function it_can_translate_a_button()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $button = Button::create('qux');
+        $message = Question::create("foo")->addButton($button);
+        $message->translate($translationCallable);
+        $this->assertSame([
+            'type' => 'actions',
+            'text' => 'FOO',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [[
+                'name' => 'QUX',
+                'text' => 'QUX',
+                'image_url' => null,
+                'type' => 'button',
+                'value' => null,
+                'additional' => [],
+            ]],
+        ], $message->toWebDriver());
+    }
+
+    /** @test */
+    public function it_can_translate_buttons()
+    {
+        $translationCallable = function ($text) {
+            return strtoupper($text);
+        };
+        $button1 = Button::create('bar');
+        $button2 = Button::create('qux');
+        $message = Question::create("foo")->addButtons([$button1, $button2]);
+        $message->translate($translationCallable);
+        $this->assertSame([
+            'type' => 'actions',
+            'text' => 'FOO',
+            'fallback' => null,
+            'callback_id' => null,
+            'actions' => [
+                [
+                    'name' => 'BAR',
+                    'text' => 'BAR',
+                    'image_url' => null,
+                    'type' => 'button',
+                    'value' => null,
+                    'additional' => [],
+                ],
+                [
+                    'name' => 'QUX',
+                    'text' => 'QUX',
+                    'image_url' => null,
+                    'type' => 'button',
+                    'value' => null,
+                    'additional' => [],
+                ],
+            ],
+        ], $message->toWebDriver());
+    }
 }

--- a/tests/Messages/QuestionTest.php
+++ b/tests/Messages/QuestionTest.php
@@ -116,7 +116,7 @@ class QuestionTest extends TestCase
         $translationCallable = function ($text) {
             return strtoupper($text);
         };
-        $button = Button::create('qux')->setName('bar');
+        $button = Button::create('qux')->name('bar');
         $message = Question::create("foo")->addAction($button);
         $message->translate($translationCallable);
         $this->assertSame([

--- a/tests/Messages/QuestionTest.php
+++ b/tests/Messages/QuestionTest.php
@@ -116,7 +116,7 @@ class QuestionTest extends TestCase
         $translationCallable = function ($text) {
             return strtoupper($text);
         };
-        $button = Button::create('qux');
+        $button = Button::create('qux')->setName('bar');
         $message = Question::create("foo")->addAction($button);
         $message->translate($translationCallable);
         $this->assertSame([
@@ -125,7 +125,7 @@ class QuestionTest extends TestCase
             'fallback' => null,
             'callback_id' => null,
             'actions' => [[
-                'name' => 'QUX',
+                'name' => 'BAR',
                 'text' => 'QUX',
                 'image_url' => null,
                 'type' => 'button',


### PR DESCRIPTION
I would like to add middleware that translates the text of messages on the way from Botman to the user. Something like this: 

```php
class TranslateMiddleware implements Sending
{
    private TranslatorInterface $translator;

    public function __construct(TranslatorInterface $translator)
    {
        $this->translator = $translator;
    }

    public function sending($payload, $next, BotMan $bot)
    {
        if ($payload instanceof TranslatableInterface) {
            $payload->translate(function($text) {
                return $this->translator->trans($text);
            });
        }
        return $next($payload);
    }
}
```

This PR attempts to make this possible. I have tried to make sure it contains no BC breaks. 